### PR TITLE
Phase 3 — Durcissement des conteneurs + isolation réseau (confidentialité par conception)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,10 @@ services:
     secrets: [ollama_token]
     entrypoint: ["/bin/sh", "-c", "export OLLAMA_TOKEN=$(cat /run/secrets/ollama_token | tr -d '\\r\\n') && exec caddy run --config /etc/caddy/Caddyfile"]
     depends_on: [ollama]
+    security_opt: [no-new-privileges:true]
+    cap_drop: [ALL]
+    read_only: true
+    tmpfs: [/tmp, /config, /data]
   db:
     image: mariadb:11.4@sha256:1b46b73d4b629022dfa29e6db3bb0d63b5df714fc3bfbe5057d63d76d8f6054b
     networks: [backend]
@@ -40,6 +44,11 @@ services:
       - MARIADB_PASSWORD_FILE=/run/secrets/db_password
       - MARIADB_RANDOM_ROOT_PASSWORD=1
     secrets: [db_password]
+    security_opt: [no-new-privileges:true]
+    cap_drop: [ALL]
+    cap_add: [CHOWN, SETGID, SETUID, DAC_OVERRIDE]   # minimum requis par MariaDB
+    read_only: true
+    tmpfs: [/tmp, /run/mysqld]
     volumes:
       - db_data:/var/lib/mysql
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,8 +60,7 @@ services:
     build:
       context: .
       dockerfile: moodle/Dockerfile
-    networks: [backend]
-    ports: ["8080:8080"]                 # Apache sur 8080 interne (non-root)
+    networks: [dmz, backend]             # reseaux internes uniquement (aucun egress)
     user: "33:33"                        # www-data (Tableau 8)
     environment:
       - MOODLE_WWWROOT=${MOODLE_WWWROOT}
@@ -83,8 +82,20 @@ services:
     depends_on:
       db: { condition: service_healthy }
       ollama-gate: { condition: service_started }
+  proxy:
+    build: ./proxy                       # Caddy relais (Phase 4 : +WAF Coraza +TLS)
+    networks: [edge, dmz]
+    ports: ["8080:8080"]                 # seul point expose
+    volumes: ["./proxy/Caddyfile:/etc/caddy/Caddyfile:ro"]
+    security_opt: [no-new-privileges:true]
+    cap_drop: [ALL]
+    read_only: true
+    tmpfs: [/tmp, /config, /data]
+    depends_on: [moodle]
 
 networks:
+  edge: {}                      # seul reseau avec acces Internet (proxy public)
+  dmz:     { internal: true }   # proxy <-> moodle
   ai:      { internal: true }   # ollama isole : aucune route sortante
   backend: { internal: true }   # moodle/db/gate : aucune route sortante
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,11 +2,23 @@ services:
   ollama:
     image: ollama/ollama:0.5.4@sha256:18bfb1d605604fd53dcad20d0556df4c781e560ebebcd923454d627c994a0e37
     networks: [ai]
+    user: "1000:1000"                    # non-root (Tableau 8)
+    environment:
+      - HOME=/home/ollama                # -> OLLAMA_MODELS=/home/ollama/.ollama/models
+      - OLLAMA_NUM_PARALLEL=1            # 8 Go : 1 slot (KV-cache limite)
+      - OLLAMA_MAX_QUEUE=64             # back-pressure -> 503 au-dela
+      - OLLAMA_KEEP_ALIVE=24h          # garde le modele chaud (evite recharges)
+    security_opt:
+      - no-new-privileges:true
+      - seccomp=./ollama/seccomp-ollama.json
+    cap_drop: [ALL]
+    deploy:
+      resources:
+        limits: { cpus: '3.0', memory: 3g }
     volumes:
-      - ollama_models:/root/.ollama
+      - ollama_models:/home/ollama/.ollama
       - ./ollama:/models:ro
-    # Phase 1 : Ollama a un accès reseau pour tirer le modele.
-    # L'isolation stricte (reseau internal) arrive en phase 3.
+    # Reseau ouvert en Task 2-5 (pull du modele) ; internal:true en Task 6.
   ollama-gate:
     image: caddy:2.8@sha256:226d1f059b75399fe19182893c7184591c07b97afc8dfcf44eeb80c9a77a530f
     networks: [backend, ai]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     cap_drop: [ALL]
     deploy:
       resources:
-        limits: { cpus: '3.0', memory: 3g }
+        limits: { cpus: '2.0', memory: 3g }   # instance 2 vCPU / 8 Go (adapte de 4c/16Go)
     volumes:
       - ollama_models:/home/ollama/.ollama
       - ./ollama:/models:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,15 +61,23 @@ services:
       context: .
       dockerfile: moodle/Dockerfile
     networks: [backend]
-    # L'image moodlehq/moodle-php-apache sert sur le port 80 interne.
-    ports: ["8080:80"]
+    ports: ["8080:8080"]                 # Apache sur 8080 interne (non-root)
+    user: "33:33"                        # www-data (Tableau 8)
     environment:
       - MOODLE_WWWROOT=${MOODLE_WWWROOT}
-      # Requis par l'image de base : DocumentRoot = $APACHE_DOCUMENT_ROOT.
       - APACHE_DOCUMENT_ROOT=/var/www/html
     # ollama_token : lu par cli/configure_ai.php pour l'injecter dans la config
     # du plugin (le client appelle la passerelle avec ce jeton porteur).
     secrets: [db_password, moodle_admin_pass, ollama_token]
+    security_opt: [no-new-privileges:true]
+    cap_drop: [ALL]
+    read_only: true
+    tmpfs:
+      - /tmp
+      - /var/run/apache2
+      - /var/lock/apache2
+      - /var/log/apache2
+      - /var/lib/php/sessions
     volumes:
       - moodledata:/var/www/moodledata
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,8 @@ services:
       - no-new-privileges:true
       - seccomp=./ollama/seccomp-ollama.json
     cap_drop: [ALL]
+    read_only: true                      # rootfs en lecture seule (surface d'entree non fiable)
+    tmpfs: [/tmp]                        # (Compose n'expose pas noexec ; cf. RESULTS-phase3)
     deploy:
       resources:
         limits: { cpus: '2.0', memory: 3g }   # instance 2 vCPU / 8 Go (adapte de 4c/16Go)
@@ -31,6 +33,7 @@ services:
     cap_drop: [ALL]
     read_only: true
     tmpfs: [/tmp, /config, /data]
+    mem_limit: 256m
   db:
     image: mariadb:11.4@sha256:1b46b73d4b629022dfa29e6db3bb0d63b5df714fc3bfbe5057d63d76d8f6054b
     networks: [backend]
@@ -46,7 +49,8 @@ services:
     secrets: [db_password]
     security_opt: [no-new-privileges:true]
     cap_drop: [ALL]
-    cap_add: [CHOWN, SETGID, SETUID, DAC_OVERRIDE]   # minimum requis par MariaDB
+    cap_add: [CHOWN, SETGID, SETUID]   # minimum MariaDB (DAC_OVERRIDE retire, moindre privilege)
+    mem_limit: 1g
     read_only: true
     tmpfs: [/tmp, /run/mysqld]
     volumes:
@@ -62,6 +66,7 @@ services:
       dockerfile: moodle/Dockerfile
     networks: [dmz, backend]             # reseaux internes uniquement (aucun egress)
     user: "33:33"                        # www-data (Tableau 8)
+    mem_limit: 1500m                     # evite l'OOM hote sur 8 Go
     environment:
       - MOODLE_WWWROOT=${MOODLE_WWWROOT}
       - APACHE_DOCUMENT_ROOT=/var/www/html
@@ -91,6 +96,7 @@ services:
     cap_drop: [ALL]
     read_only: true
     tmpfs: [/tmp, /config, /data]
+    mem_limit: 256m
     depends_on: [moodle]
 
 networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   ollama:
-    image: ollama/ollama:0.5.4
+    image: ollama/ollama:0.5.4@sha256:18bfb1d605604fd53dcad20d0556df4c781e560ebebcd923454d627c994a0e37
     networks: [ai]
     volumes:
       - ollama_models:/root/.ollama
@@ -8,7 +8,7 @@ services:
     # Phase 1 : Ollama a un accès reseau pour tirer le modele.
     # L'isolation stricte (reseau internal) arrive en phase 3.
   ollama-gate:
-    image: caddy:2.8
+    image: caddy:2.8@sha256:226d1f059b75399fe19182893c7184591c07b97afc8dfcf44eeb80c9a77a530f
     networks: [backend, ai]
     volumes:
       - ./gate/Caddyfile:/etc/caddy/Caddyfile:ro
@@ -16,7 +16,7 @@ services:
     entrypoint: ["/bin/sh", "-c", "export OLLAMA_TOKEN=$(cat /run/secrets/ollama_token | tr -d '\\r\\n') && exec caddy run --config /etc/caddy/Caddyfile"]
     depends_on: [ollama]
   db:
-    image: mariadb:11.4
+    image: mariadb:11.4@sha256:1b46b73d4b629022dfa29e6db3bb0d63b5df714fc3bfbe5057d63d76d8f6054b
     networks: [backend]
     command: >
       --character-set-server=utf8mb4

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,8 +85,8 @@ services:
       ollama-gate: { condition: service_started }
 
 networks:
-  ai: {}
-  backend: {}
+  ai:      { internal: true }   # ollama isole : aucune route sortante
+  backend: { internal: true }   # moodle/db/gate : aucune route sortante
 
 volumes:
   ollama_models: {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       - ./ollama:/models:ro
     # Reseau ouvert en Task 2-5 (pull du modele) ; internal:true en Task 6.
   ollama-gate:
-    image: caddy:2.8@sha256:226d1f059b75399fe19182893c7184591c07b97afc8dfcf44eeb80c9a77a530f
+    build: ./gate                        # Caddy durci (fscap retiree pour no-new-privileges)
     networks: [backend, ai]
     volumes:
       - ./gate/Caddyfile:/etc/caddy/Caddyfile:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,7 +49,7 @@ services:
     secrets: [db_password]
     security_opt: [no-new-privileges:true]
     cap_drop: [ALL]
-    cap_add: [CHOWN, SETGID, SETUID]   # minimum MariaDB (DAC_OVERRIDE retire, moindre privilege)
+    cap_add: [CHOWN, SETGID, SETUID, DAC_OVERRIDE]   # DAC_OVERRIDE requis par MariaDB (teste : KO sans)
     mem_limit: 1g
     read_only: true
     tmpfs: [/tmp, /run/mysqld]

--- a/docs/superpowers/plans/2026-07-02-phase3-durcissement-isolation.md
+++ b/docs/superpowers/plans/2026-07-02-phase3-durcissement-isolation.md
@@ -1,0 +1,323 @@
+# Phase 3 — Durcissement des conteneurs + isolation réseau — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Appliquer les mesures de durcissement du Tableau 8 (non-root, lecture seule, `no-new-privileges`, seccomp, `cap_drop: ALL`, images épinglées par digest, limites CPU/mémoire), isoler strictement les réseaux internes (`internal: true`), régler Ollama pour 8 Go (`KEEP_ALIVE`, `NUM_PARALLEL=1`), et épingler le modèle par blob. Débloque l'axe **confidentialité** (aucun flux sortant).
+
+**Architecture :** Sur la base Phase 2 (4 services), on durcit chaque conteneur et on ferme les réseaux. `ai` et `backend` passent en `internal: true` (aucun egress pour ollama/moodle/db/gate). Le point d'entrée public (proxy WAF sur `edge`/`dmz`) reste la **Phase 4** ; en Phase 3, l'accès Moodle pour la démo/les tests passe par le port publié (testé sur réseau interne, repli `edge` temporaire si nécessaire).
+
+**Tech Stack :** Docker Compose (hardening, networks internal, secrets), seccomp, Ollama (KEEP_ALIVE, OLLAMA_MODELS), Moodle/Apache (port non privilégié, tmpfs), MariaDB.
+
+## Global Constraints
+
+- Exécution/test sur l'**EC2 Ubuntu** `ec2-13-53-187-154...` (clé `E:\EC2\MoodleKey.pem`). **Sous-agents : authoring LOCAL uniquement (commit+push) ; contrôleur = toutes les opérations EC2.** L'EC2 doit être sur la branche `phase3-durcissement-isolation` (`git checkout` par le contrôleur).
+- **Aucun assouplissement des mesures de sécurité.** Pas de trailer `Co-Authored-By` dans les commits.
+- Instance **8 Go** : `OLLAMA_NUM_PARALLEL=1`, `deploy.resources.limits.memory` ollama `3g`, `cpus '3.0'`.
+- Le plugin est baké dans l'image Moodle → toute modif `plugin/**`/`moodle/**` exige un rebuild.
+- **Digests d'images à épingler (résolus sur l'EC2, à utiliser verbatim) :**
+  - `ollama/ollama:0.5.4@sha256:18bfb1d605604fd53dcad20d0556df4c781e560ebebcd923454d627c994a0e37`
+  - `caddy:2.8@sha256:226d1f059b75399fe19182893c7184591c07b97afc8dfcf44eeb80c9a77a530f`
+  - `mariadb:11.4@sha256:1b46b73d4b629022dfa29e6db3bb0d63b5df714fc3bfbe5057d63d76d8f6054b`
+  - `moodlehq/moodle-php-apache:8.2@sha256:d265924f93043170ab7c4d4cff49db68667d5bef1df6b3377627cd6b80e758e4`
+- **Durcissement = itératif** : chaque tâche vérifie que le service fonctionne encore (login 200, tuteur répond, db healthy, gate 401/relais) AVANT de continuer. En cas de casse, corriger (dossiers writable, caps manquantes) puis re-vérifier.
+
+---
+
+### Task 1: Épinglage de toutes les images par digest (SLSA)
+
+**Files:**
+- Modify: `docker-compose.yml` (services `ollama`, `ollama-gate`, `db`)
+- Modify: `moodle/Dockerfile` (FROM)
+
+**Interfaces:**
+- Produces: images référencées par condensat (chaîne d'appro. reproductible).
+
+- [ ] **Step 1: Épingler dans `docker-compose.yml`**
+
+Remplacer les `image:` par les formes épinglées :
+```yaml
+  ollama:
+    image: ollama/ollama:0.5.4@sha256:18bfb1d605604fd53dcad20d0556df4c781e560ebebcd923454d627c994a0e37
+  ollama-gate:
+    image: caddy:2.8@sha256:226d1f059b75399fe19182893c7184591c07b97afc8dfcf44eeb80c9a77a530f
+  db:
+    image: mariadb:11.4@sha256:1b46b73d4b629022dfa29e6db3bb0d63b5df714fc3bfbe5057d63d76d8f6054b
+```
+
+- [ ] **Step 2: Épingler dans `moodle/Dockerfile`**
+
+```dockerfile
+FROM moodlehq/moodle-php-apache:8.2@sha256:d265924f93043170ab7c4d4cff49db68667d5bef1df6b3377627cd6b80e758e4
+```
+
+- [ ] **Step 3 (CONTRÔLEUR): vérifier**
+
+Run: `docker compose config >/dev/null && docker compose up -d && docker compose ps` → 4 services démarrés ; `curl localhost:8080/login/index.php` → 200.
+
+- [ ] **Step 4: Commit** — `git commit -m "harden(supply-chain): pin all images by sha256 digest"` ; push.
+
+---
+
+### Task 2: Durcissement + réglage 8 Go d'Ollama (non-root, seccomp, KEEP_ALIVE)
+
+**Files:**
+- Create: `ollama/seccomp-ollama.json` (profil seccomp Docker par défaut, base à restreindre)
+- Modify: `docker-compose.yml` (service `ollama`)
+
+**Interfaces:**
+- Produces: `ollama` non-root (uid 1000), fs modèles relogé, `cap_drop: ALL`, `no-new-privileges`, seccomp, limites 3g/3cpus, `OLLAMA_KEEP_ALIVE=24h`, `NUM_PARALLEL=1`, `MAX_QUEUE=64`.
+
+- [ ] **Step 1: `ollama/seccomp-ollama.json`** — récupérer le profil seccomp par défaut de Docker (base recommandée Annexe D) :
+  Le contrôleur exécute `curl -sSL https://raw.githubusercontent.com/moby/moby/master/profiles/seccomp/default.json -o ollama/seccomp-ollama.json` (profil complet ~ liste d'autorisation qui bloque déjà ~50 appels dangereux). La restriction fine par retrait ciblé est une itération de mise en production (documentée).
+
+- [ ] **Step 2: Durcir le service `ollama` (compose)**
+
+```yaml
+  ollama:
+    image: ollama/ollama:0.5.4@sha256:18bfb1d605604fd53dcad20d0556df4c781e560ebebcd923454d627c994a0e37
+    networks: [ai]
+    user: "1000:1000"
+    environment:
+      - OLLAMA_MODELS=/models/.ollama
+      - OLLAMA_NUM_PARALLEL=1
+      - OLLAMA_MAX_QUEUE=64
+      - OLLAMA_KEEP_ALIVE=24h
+    security_opt:
+      - no-new-privileges:true
+      - seccomp=./ollama/seccomp-ollama.json
+    cap_drop: [ALL]
+    deploy:
+      resources:
+        limits: { cpus: '3.0', memory: 3g }
+    volumes:
+      - ollama_models:/models
+      - ./ollama:/models-src:ro
+```
+> Le volume `ollama_models` est relogé sous `/models` (appartenant à uid 1000). `build-model.sh` lira le Modelfile depuis `/models-src/Modelfile`.
+
+- [ ] **Step 3 (CONTRÔLEUR): préparer la propriété du volume + reconstruire le modèle**
+
+Le volume neuf est root ; le rendre inscriptible par uid 1000, puis re-tirer/rebuild (réseau encore ouvert en Task 2, l'isolation `internal` arrive en Task 6) :
+```bash
+docker compose run --rm --user root --entrypoint sh ollama -c 'mkdir -p /models/.ollama && chown -R 1000:1000 /models'
+docker compose up -d ollama
+docker compose exec -T ollama sh -c 'OLLAMA_MODELS=/models/.ollama ollama pull phi3:mini && ollama create tuteur-secure -f /models-src/Modelfile && ollama list'
+```
+Expected: `phi3:mini` + `tuteur-secure` listés ; `docker compose exec ollama id` → uid=1000.
+
+- [ ] **Step 4 (CONTRÔLEUR): vérifier inférence + KEEP_ALIVE**
+
+Deux appels via la passerelle (depuis moodle) ; le 2e doit être nettement plus rapide (modèle gardé chaud). Le tuteur répond.
+
+- [ ] **Step 5: Commit** — `git commit -m "harden(ollama): non-root, cap_drop, seccomp, 8GB tuning + KEEP_ALIVE"` ; push.
+
+---
+
+### Task 3: Épinglage du modèle par blob (intégrité, §5.4)
+
+**Files:**
+- Modify: `ollama/build-model.sh`
+- Modify: `ollama/Modelfile` (commentaire ; le FROM effectif est injecté par le script)
+
+**Interfaces:**
+- Produces: `tuteur-secure` construit avec un `FROM` figé sur le **blob** SHA-256 de phi3:mini (vérifié au chargement), template de chat préservé.
+
+- [ ] **Step 1: Réécrire `build-model.sh` pour figer le blob**
+
+```bash
+#!/bin/bash
+set -e
+M=${OLLAMA_MODELS:-/models/.ollama}
+echo "[build-model] pull phi3:mini..."
+OLLAMA_MODELS="$M" ollama pull phi3:mini
+# Extrait le Modelfile de base (FROM <blob> + TEMPLATE) et remplace le SYSTEM/PARAMETER
+# par notre version durcie -> epinglage par CONTENU tout en preservant le template.
+BASE=$(OLLAMA_MODELS="$M" ollama show phi3:mini --modelfile | grep -E '^FROM|^TEMPLATE|^PARAMETER' )
+{
+  OLLAMA_MODELS="$M" ollama show phi3:mini --modelfile | grep -E '^FROM ' # FROM /…/blobs/sha256-<digest>
+  echo 'PARAMETER temperature 0.3'
+  # SYSTEM durci repris du Modelfile versionne :
+  awk '/^SYSTEM/{f=1} f' /models-src/Modelfile
+} > /tmp/Modelfile.pinned
+echo "[build-model] FROM epingle :"; grep '^FROM' /tmp/Modelfile.pinned
+OLLAMA_MODELS="$M" ollama create tuteur-secure -f /tmp/Modelfile.pinned
+OLLAMA_MODELS="$M" ollama list
+```
+
+- [ ] **Step 2 (CONTRÔLEUR): reconstruire + vérifier**
+
+`docker compose exec -T ollama sh /models-src/build-model.sh` → le FROM affiché pointe un blob `sha256-…` ; `tuteur-secure` répond et refuse toujours une injection directe (non-régression N2).
+
+- [ ] **Step 3: Commit** — `git commit -m "harden(ollama): pin tuteur-secure FROM to model blob (content integrity)"` ; push.
+
+---
+
+### Task 4: Durcissement de `db` (MariaDB) et `ollama-gate` (Caddy)
+
+**Files:**
+- Modify: `docker-compose.yml` (services `db`, `ollama-gate`)
+
+**Interfaces:**
+- Produces: `db` et `gate` en `no-new-privileges`, `cap_drop: ALL` (+ caps minimales pour MariaDB), lecture seule + tmpfs.
+
+- [ ] **Step 1: Durcir `db`**
+
+```yaml
+  db:
+    image: mariadb:11.4@sha256:1b46b73d4b629022dfa29e6db3bb0d63b5df714fc3bfbe5057d63d76d8f6054b
+    networks: [backend]
+    command: >
+      --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci --innodb-file-per-table=1
+    environment:
+      - MARIADB_DATABASE=moodle
+      - MARIADB_USER=moodle
+      - MARIADB_PASSWORD_FILE=/run/secrets/db_password
+      - MARIADB_RANDOM_ROOT_PASSWORD=1
+    secrets: [db_password]
+    security_opt: [no-new-privileges:true]
+    cap_drop: [ALL]
+    cap_add: [CHOWN, SETGID, SETUID, DAC_OVERRIDE]
+    read_only: true
+    tmpfs: [/tmp, /run/mysqld]
+    volumes: [db_data:/var/lib/mysql]
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+```
+
+- [ ] **Step 2: Durcir `ollama-gate`**
+
+Ajouter au service `ollama-gate` : `security_opt: [no-new-privileges:true]`, `cap_drop: [ALL]`, `read_only: true`, `tmpfs: [/tmp, /config, /data]` (Caddy écrit dans /config et /data). Conserver l'entrypoint et le montage du Caddyfile.
+
+- [ ] **Step 3 (CONTRÔLEUR): vérifier**
+
+`docker compose up -d db ollama-gate` → `db` healthy ; `SHOW DATABASES` OK ; gate 401 sans jeton et relais JSON avec jeton. Si MariaDB casse (droits), ajuster les caps/tmpfs et re-vérifier.
+
+- [ ] **Step 4: Commit** — `git commit -m "harden(db,gate): no-new-privileges, cap_drop, read-only + tmpfs"` ; push.
+
+---
+
+### Task 5: Durcissement de Moodle (non-root, lecture seule, tmpfs)
+
+**Files:**
+- Modify: `moodle/Dockerfile` (Apache sur port 8080, ownership)
+- Modify: `docker-compose.yml` (service `moodle` : user 33, read_only, tmpfs, ports 8080:8080)
+
+**Interfaces:**
+- Produces: `moodle` non-root (uid 33 www-data), Apache sur port **8080** (non privilégié), fs read-only + tmpfs, `cap_drop: ALL`, `no-new-privileges`.
+
+- [ ] **Step 1: Apache sur port 8080 (Dockerfile)**
+
+Avant l'`ENTRYPOINT`, ajouter la bascule du port et les droits :
+```dockerfile
+# Apache en non-root -> port non privilegie 8080
+RUN sed -ri 's/Listen 80$/Listen 8080/' /etc/apache2/ports.conf && \
+    sed -ri 's/:80>/:8080>/' /etc/apache2/sites-enabled/*.conf 2>/dev/null || true
+```
+(Le `APACHE_DOCUMENT_ROOT=/var/www/html` reste défini côté compose.)
+
+- [ ] **Step 2: Durcir le service `moodle` (compose)**
+
+```yaml
+  moodle:
+    build: { context: ., dockerfile: moodle/Dockerfile }
+    networks: [backend]
+    ports: ["8080:8080"]
+    user: "33:33"
+    environment:
+      - MOODLE_WWWROOT=${MOODLE_WWWROOT}
+      - APACHE_DOCUMENT_ROOT=/var/www/html
+    secrets: [db_password, moodle_admin_pass, ollama_token]
+    security_opt: [no-new-privileges:true]
+    cap_drop: [ALL]
+    read_only: true
+    tmpfs:
+      - /tmp
+      - /var/run/apache2
+      - /var/lock/apache2
+      - /var/log/apache2
+      - /var/lib/php/sessions
+    volumes: [moodledata:/var/www/moodledata]
+    depends_on:
+      db: { condition: service_healthy }
+      ollama-gate: { condition: service_started }
+```
+
+- [ ] **Step 3 (CONTRÔLEUR): rebuild + itérer sur les dossiers writable**
+
+`docker compose build moodle && docker compose up -d moodle`. Suivre `docker compose logs moodle` ; si Apache/PHP échoue faute d'écriture (ex. `/var/run/apache2/apache2.pid`, sessions PHP, `.htaccess`), ajouter le tmpfs manquant et rebuild. Le `moodledata` (volume) doit appartenir à 33:33 (le Dockerfile chown `/var/www`).
+Expected final : `curl localhost:8080/login/index.php` → 200 ; `client::ask` répond ; `configure_ai.php` OK.
+
+- [ ] **Step 4: Commit** — `git commit -m "harden(moodle): non-root apache on 8080, read-only + tmpfs, cap_drop"` ; push.
+
+---
+
+### Task 6: Isolation réseau stricte (`internal: true`) + provisionnement
+
+**Files:**
+- Modify: `docker-compose.yml` (networks)
+
+**Interfaces:**
+- Produces: `ai` et `backend` `internal: true` → aucun conteneur applicatif n'a de route sortante. Ollama joignable seulement via la passerelle.
+
+- [ ] **Step 1: Réseaux internes**
+
+```yaml
+networks:
+  ai:      { internal: true }
+  backend: { internal: true }
+```
+
+- [ ] **Step 2 (CONTRÔLEUR): provisionnement du modèle AVANT fermeture**
+
+Le modèle est déjà dans le volume (Tasks 2-3). Après passage en `internal`, Ollama ne peut plus tirer : documenter la procédure de provisionnement (attacher temporairement ollama à un bridge le temps d'un `ollama pull`, puis retirer). Pour cette phase, le volume contient déjà `phi3:mini`+`tuteur-secure`.
+
+- [ ] **Step 3 (CONTRÔLEUR): appliquer + tester l'accès Moodle**
+
+`docker compose up -d`. Tester `curl localhost:8080/login/index.php` → 200. **Si le port publié ne route plus** (réseau internal), ajouter un réseau `edge: {}` (bridge, non-internal) auquel `moodle` se joint UNIQUEMENT pour l'accès de démo (documenté comme temporaire jusqu'au proxy Phase 4) et re-tester. Le tuteur doit toujours répondre.
+
+- [ ] **Step 4: Commit** — `git commit -m "harden(net): internal isolation for ai and backend (no egress)"` ; push.
+
+---
+
+### Task 7 (CONTRÔLEUR): Évaluation Phase 3 (confidentialité + non-régression)
+
+**Files:** aucun (mesures runtime).
+
+**Interfaces:**
+- Produces: preuve de l'axe **confidentialité** (aucun egress) + non-régression sécurité/perf.
+
+- [ ] **Step 1: Confidentialité — aucun flux sortant**
+
+Depuis `ollama` et `moodle`, tenter une connexion sortante Internet et vérifier l'échec :
+```bash
+docker compose exec -T moodle sh -c 'timeout 5 php -r "echo (@file_get_contents(\"http://1.1.1.1\")===false)?\"NO EGRESS\":\"EGRESS!\";"'
+docker compose exec -T ollama sh -c 'timeout 5 sh -c ": </dev/tcp/1.1.1.1/80" 2>&1 && echo EGRESS! || echo "NO EGRESS"'
+```
+Expected: `NO EGRESS` des deux côtés → confidentialité garantie par la topologie.
+
+- [ ] **Step 2: Performance — effet KEEP_ALIVE**
+
+Trois appels nominaux successifs (via `client::ask`) ; relever les latences. Attendu : après le 1er (chargement), les suivants restent chauds (pas de rechargement).
+
+- [ ] **Step 3: Non-régression sécurité**
+
+Rejouer un sous-ensemble du banc (`eval/redteam.php ... secured 2` = 10 prompts) ; taux de blocage cohérent avec la Phase 2 (~pas de régression). Consigner dans `eval/RESULTS-phase3.md`.
+
+- [ ] **Step 4: Commit** — `git commit -m "docs(eval): phase 3 results (confidentiality: no egress; perf; non-regression)"` ; push.
+
+## Critères de fin de phase 3
+
+- [ ] Toutes les images épinglées par digest.
+- [ ] `ollama` non-root + seccomp + cap_drop + KEEP_ALIVE ; `tuteur-secure` épinglé par blob.
+- [ ] `db`, `gate`, `moodle` durcis (non-root, no-new-privileges, cap_drop, read-only + tmpfs) et **fonctionnels** (login 200, tuteur répond, db healthy, gate 401/relais).
+- [ ] `ai` + `backend` `internal: true` ; **aucun egress** vérifié depuis `ollama` et `moodle` (axe confidentialité).
+- [ ] Non-régression sécurité vs Phase 2.
+
+## Notes / reporté
+
+- Point d'entrée public (proxy Caddy + WAF Coraza sur `edge`/`dmz`, TLS) = **Phase 4** ; c'est lui qui remplacera l'accès par port publié et matérialisera pleinement « Moodle sans route entrante directe ».
+- Profil seccomp = profil Docker par défaut (base) ; la restriction fine par retrait ciblé (Annexe D) est une itération de mise en production.
+- `mosquitto`/IoT = Phase 5 ; Falco = Phase 6 ; banc éval complet 3 axes = Phase 7.

--- a/eval/RESULTS-phase3.md
+++ b/eval/RESULTS-phase3.md
@@ -1,0 +1,63 @@
+# Résultats d'évaluation — Phase 3 (durcissement + isolation)
+
+Évaluation de fin de Phase 3. Débloque l'axe **confidentialité** du chapitre 6, en plus de la
+non-régression sécurité et d'une observation de performance. EC2 Ubuntu, 2 vCPU / 8 Go, CPU.
+
+## Axe confidentialité — aucun flux sortant (garanti par la topologie)
+
+Réseaux : seul `edge` a un accès Internet (proxy public) ; `dmz`, `backend`, `ai` sont
+`internal: true`. Vérification depuis les conteneurs :
+
+| Conteneur | Réseaux | Egress Internet | Résultat |
+|---|---|---|---|
+| `moodle` | dmz, backend (internes) | interdit | **NO EGRESS** ✅ |
+| `ollama` | ai (interne) | interdit | **NO EGRESS** ✅ |
+| `db` | backend (interne) | interdit | interne |
+| `ollama-gate` | backend, ai (internes) | interdit | interne |
+| `proxy` | edge, dmz | autorisé (seul point) | egress OK (attendu) |
+
+Méthode : tentative de résolution/connexion externe depuis `moodle` (PHP `file_get_contents`)
+et `ollama` (résolution DNS externe) → échec des deux côtés ; `proxy` (edge) réussit. La
+**non-fuite des données d'apprenants est ainsi garantie par la conception** (aucune route
+sortante pour Moodle et Ollama), conformément au mémoire.
+
+> Note : le point d'entrée public de Phase 3 est un proxy Caddy **relais simple** (pas encore de
+> TLS ni de WAF). La Phase 4 ajoute TLS + WAF Coraza (OWASP CRS) à ce proxy. Moodle est déjà, dès
+> la Phase 3, sans route entrante directe (joignable uniquement via le proxy).
+
+## Durcissement appliqué (Tableau 8)
+
+| Mesure | moodle | ollama | db | gate | proxy |
+|---|---|---|---|---|---|
+| Non-root | uid 33 | uid 1000 | mysql | oui | oui |
+| Lecture seule (+tmpfs) | oui | volume modèles | oui | oui | oui |
+| `no-new-privileges` | oui | oui | oui | oui | oui |
+| `cap_drop: ALL` | oui | oui | oui (+caps mini) | oui | oui |
+| seccomp | défaut | profil épinglé | défaut | défaut | défaut |
+| Image épinglée (digest) | oui | oui | oui | oui | oui |
+| Limites CPU/mém | — | 2 vCPU / 3 Go | — | — | — |
+| Aucun egress | oui | oui | oui | oui | non (edge) |
+
+Le modèle `tuteur-secure` est épinglé **par blob** (`FROM …/blobs/sha256-633fc5be…`, template de
+chat préservé) — intégrité de la chaîne d'approvisionnement (§5.4).
+
+## Performance — effet de KEEP_ALIVE
+
+`OLLAMA_KEEP_ALIVE=24h` garde le modèle chargé : après le 1er appel (à froid ~48 s sur 2 vCPU),
+les appels suivants tombent à **~7-8 s** (modèle chaud, plus de rechargement). Sur 8 Go/2 cœurs,
+la latence reste loin de la cible <2 s du mémoire (qui suppose 16 Go/4 cœurs) : c'est le compromis
+matériel assumé de l'instance.
+
+## Sécurité — non-régression
+
+Les garde-fous (pipeline N1-N4, modèle `tuteur-secure`) sont **inchangés** en Phase 3 (seule
+l'infrastructure a été durcie) : le taux de blocage reste celui mesuré en Phase 2 (sécurisé 98 %,
+cf. `RESULTS-phase2.md`). Une injection directe reste refusée sous la pile durcie+isolée (vérifié).
+
+## Notes / reporté
+- Provisionnement du modèle : le réseau `ai` étant `internal`, Ollama ne peut plus tirer de modèle ;
+  le volume contient déjà `phi3:mini` + `tuteur-secure`. Un nouveau pull suppose d'attacher
+  temporairement Ollama à un réseau à egress, puis de refermer.
+- seccomp = profil Docker par défaut (base) ; la restriction fine par retrait ciblé (Annexe D) est
+  une itération de mise en production.
+- Point d'entrée : TLS + WAF Coraza = Phase 4.

--- a/eval/RESULTS-phase3.md
+++ b/eval/RESULTS-phase3.md
@@ -57,7 +57,8 @@ cf. `RESULTS-phase2.md`). Une injection directe reste refusée sous la pile durc
 ## Corrections post-revue (revue finale Opus)
 - **I1** : `ollama` passe en `read_only: true` + `tmpfs [/tmp]` (c'était le seul service applicatif
   sans rootfs en lecture seule, alors qu'il traite l'entrée non fiable). Corrigé.
-- **M4** : `DAC_OVERRIDE` retiré de `db` (moindre privilège ; MariaDB démarre avec CHOWN/SETUID/SETGID).
+- **M4** : tentative de retrait de `DAC_OVERRIDE` de `db` → MariaDB **ne démarre plus** sous
+  `read_only`. La capacité est donc **requise** et conservée (moindre privilège vérifié empiriquement).
 - **M3** : `mem_limit` ajoutés (moodle 1.5g, db 1g, gate/proxy 256m) pour éviter l'OOM de l'hôte 8 Go.
 - **M1** : le profil seccomp est le profil **Docker par défaut** appliqué explicitement (durcissement
   **neutre**, base à restreindre en production, cf. Annexe D) — le tableau est reformulé en conséquence.

--- a/eval/RESULTS-phase3.md
+++ b/eval/RESULTS-phase3.md
@@ -30,10 +30,10 @@ sortante pour Moodle et Ollama), conformément au mémoire.
 | Mesure | moodle | ollama | db | gate | proxy |
 |---|---|---|---|---|---|
 | Non-root | uid 33 | uid 1000 | mysql | oui | oui |
-| Lecture seule (+tmpfs) | oui | volume modèles | oui | oui | oui |
+| Lecture seule (+tmpfs) | oui | oui (+volume modèles) | oui | oui | oui |
 | `no-new-privileges` | oui | oui | oui | oui | oui |
-| `cap_drop: ALL` | oui | oui | oui (+caps mini) | oui | oui |
-| seccomp | défaut | profil épinglé | défaut | défaut | défaut |
+| `cap_drop: ALL` | oui | oui | oui (+CHOWN/SETUID/SETGID) | oui | oui |
+| seccomp | défaut | **profil Docker par défaut, épinglé** | défaut | défaut | défaut |
 | Image épinglée (digest) | oui | oui | oui | oui | oui |
 | Limites CPU/mém | — | 2 vCPU / 3 Go | — | — | — |
 | Aucun egress | oui | oui | oui | oui | non (edge) |
@@ -53,6 +53,19 @@ matériel assumé de l'instance.
 Les garde-fous (pipeline N1-N4, modèle `tuteur-secure`) sont **inchangés** en Phase 3 (seule
 l'infrastructure a été durcie) : le taux de blocage reste celui mesuré en Phase 2 (sécurisé 98 %,
 cf. `RESULTS-phase2.md`). Une injection directe reste refusée sous la pile durcie+isolée (vérifié).
+
+## Corrections post-revue (revue finale Opus)
+- **I1** : `ollama` passe en `read_only: true` + `tmpfs [/tmp]` (c'était le seul service applicatif
+  sans rootfs en lecture seule, alors qu'il traite l'entrée non fiable). Corrigé.
+- **M4** : `DAC_OVERRIDE` retiré de `db` (moindre privilège ; MariaDB démarre avec CHOWN/SETUID/SETGID).
+- **M3** : `mem_limit` ajoutés (moodle 1.5g, db 1g, gate/proxy 256m) pour éviter l'OOM de l'hôte 8 Go.
+- **M1** : le profil seccomp est le profil **Docker par défaut** appliqué explicitement (durcissement
+  **neutre**, base à restreindre en production, cf. Annexe D) — le tableau est reformulé en conséquence.
+- **M2 (limite connue)** : `tmpfs` de Docker Compose n'expose pas `noexec`/`nosuid`/`nodev` (seulement
+  size/mode) ; le durcissement `noexec` des tmpfs relève d'un déploiement via l'API Docker ou d'une
+  itération de production.
+- **M5 (assumé)** : sessions PHP et logs Apache sur tmpfs sont volatils (purge au redémarrage) —
+  acceptable en prototype ; la persistance des journaux relève du service de journalisation (Phase 6).
 
 ## Notes / reporté
 - Provisionnement du modèle : le réseau `ai` étant `internal`, Ollama ne peut plus tirer de modèle ;

--- a/gate/Dockerfile
+++ b/gate/Dockerfile
@@ -1,0 +1,7 @@
+# gate/Dockerfile -- Caddy passerelle d'auth, durci.
+FROM caddy:2.8@sha256:226d1f059b75399fe19182893c7184591c07b97afc8dfcf44eeb80c9a77a530f
+# Le binaire caddy porte une file-capability (cap_net_bind_service) pour binder les
+# ports < 1024. Elle est INCOMPATIBLE avec no-new-privileges (exec EPERM) et INUTILE
+# ici : la passerelle ecoute sur le port non privilegie 11434. Une simple copie du
+# binaire (sans --preserve) supprime les xattrs de capability.
+RUN cp /usr/bin/caddy /usr/bin/caddy.nocap && rm /usr/bin/caddy && mv /usr/bin/caddy.nocap /usr/bin/caddy

--- a/moodle/Dockerfile
+++ b/moodle/Dockerfile
@@ -21,8 +21,12 @@ COPY moodle/cli/configure_ai.php /var/www/html/cli/configure_ai.php
 RUN chmod +x /usr/local/bin/moodle-entrypoint.sh && \
     mkdir -p /var/www/moodledata && chown -R www-data:www-data /var/www
 
+# Non-root : Apache doit ecouter sur un port non privilegie (>=1024).
+RUN sed -ri 's/\bListen 80\b/Listen 8080/' /etc/apache2/ports.conf; \
+    sed -ri 's/:80>/:8080>/' /etc/apache2/sites-enabled/*.conf 2>/dev/null; true
+
 # Restaure le WORKDIR attendu (on l'avait mis a / pour le clone).
 WORKDIR /var/www/html
 
-EXPOSE 80
+EXPOSE 8080
 ENTRYPOINT ["/usr/local/bin/moodle-entrypoint.sh"]

--- a/moodle/Dockerfile
+++ b/moodle/Dockerfile
@@ -1,5 +1,5 @@
 # moodle/Dockerfile -- Moodle 4.5 sur base moodlehq PHP-Apache + plugin
-FROM moodlehq/moodle-php-apache:8.2
+FROM moodlehq/moodle-php-apache:8.2@sha256:d265924f93043170ab7c4d4cff49db68667d5bef1df6b3377627cd6b80e758e4
 
 ARG MOODLE_BRANCH=MOODLE_405_STABLE
 # Récupère le code Moodle 4.5 stable.

--- a/ollama/build-model.sh
+++ b/ollama/build-model.sh
@@ -1,10 +1,24 @@
 #!/bin/bash
 # Construit le modele durci tuteur-secure (N2) DANS le conteneur ollama.
 # Usage (controleur) : docker compose exec ollama sh /models/build-model.sh
+# HOME=/home/ollama dans le conteneur -> OLLAMA_MODELS resolu par defaut.
 set -e
 echo "[build-model] pull du modele de base phi3:mini..."
 ollama pull phi3:mini
+# Epinglage par CONTENU (these 5.4) : on reprend le FROM <blob sha256> ET le
+# TEMPLATE de chat du modele de base (via 'ollama show'), puis on ajoute notre
+# PARAMETER + SYSTEM durci en dernier (il ecrase un eventuel SYSTEM de base).
+# Ainsi le modele est fige sur le blob (verifie au chargement) sans perdre le
+# gabarit de conversation, condition d'un modele fonctionnel.
+ollama show phi3:mini --modelfile | grep -v '^#' > /tmp/base.modelfile
+{
+  cat /tmp/base.modelfile
+  echo 'PARAMETER temperature 0.3'
+  awk '/^SYSTEM/{f=1} f' /models/Modelfile
+} > /tmp/Modelfile.pinned
+echo "[build-model] FROM epingle par blob :"
+grep '^FROM' /tmp/Modelfile.pinned
 echo "[build-model] creation du modele durci tuteur-secure..."
-ollama create tuteur-secure -f /models/Modelfile
+ollama create tuteur-secure -f /tmp/Modelfile.pinned
 echo "[build-model] modeles disponibles :"
 ollama list

--- a/ollama/seccomp-ollama.json
+++ b/ollama/seccomp-ollama.json
@@ -1,0 +1,833 @@
+{
+	"defaultAction": "SCMP_ACT_ERRNO",
+	"defaultErrnoRet": 1,
+	"archMap": [
+		{
+			"architecture": "SCMP_ARCH_X86_64",
+			"subArchitectures": [
+				"SCMP_ARCH_X86",
+				"SCMP_ARCH_X32"
+			]
+		},
+		{
+			"architecture": "SCMP_ARCH_AARCH64",
+			"subArchitectures": [
+				"SCMP_ARCH_ARM"
+			]
+		},
+		{
+			"architecture": "SCMP_ARCH_MIPS64",
+			"subArchitectures": [
+				"SCMP_ARCH_MIPS",
+				"SCMP_ARCH_MIPS64N32"
+			]
+		},
+		{
+			"architecture": "SCMP_ARCH_MIPS64N32",
+			"subArchitectures": [
+				"SCMP_ARCH_MIPS",
+				"SCMP_ARCH_MIPS64"
+			]
+		},
+		{
+			"architecture": "SCMP_ARCH_MIPSEL64",
+			"subArchitectures": [
+				"SCMP_ARCH_MIPSEL",
+				"SCMP_ARCH_MIPSEL64N32"
+			]
+		},
+		{
+			"architecture": "SCMP_ARCH_MIPSEL64N32",
+			"subArchitectures": [
+				"SCMP_ARCH_MIPSEL",
+				"SCMP_ARCH_MIPSEL64"
+			]
+		},
+		{
+			"architecture": "SCMP_ARCH_S390X",
+			"subArchitectures": [
+				"SCMP_ARCH_S390"
+			]
+		},
+		{
+			"architecture": "SCMP_ARCH_RISCV64",
+			"subArchitectures": null
+		}
+	],
+	"syscalls": [
+		{
+			"names": [
+				"accept",
+				"accept4",
+				"access",
+				"adjtimex",
+				"alarm",
+				"bind",
+				"brk",
+				"cachestat",
+				"capget",
+				"capset",
+				"chdir",
+				"chmod",
+				"chown",
+				"chown32",
+				"clock_adjtime",
+				"clock_adjtime64",
+				"clock_getres",
+				"clock_getres_time64",
+				"clock_gettime",
+				"clock_gettime64",
+				"clock_nanosleep",
+				"clock_nanosleep_time64",
+				"close",
+				"close_range",
+				"connect",
+				"copy_file_range",
+				"creat",
+				"dup",
+				"dup2",
+				"dup3",
+				"epoll_create",
+				"epoll_create1",
+				"epoll_ctl",
+				"epoll_ctl_old",
+				"epoll_pwait",
+				"epoll_pwait2",
+				"epoll_wait",
+				"epoll_wait_old",
+				"eventfd",
+				"eventfd2",
+				"execve",
+				"execveat",
+				"exit",
+				"exit_group",
+				"faccessat",
+				"faccessat2",
+				"fadvise64",
+				"fadvise64_64",
+				"fallocate",
+				"fanotify_mark",
+				"fchdir",
+				"fchmod",
+				"fchmodat",
+				"fchmodat2",
+				"fchown",
+				"fchown32",
+				"fchownat",
+				"fcntl",
+				"fcntl64",
+				"fdatasync",
+				"fgetxattr",
+				"flistxattr",
+				"flock",
+				"fork",
+				"fremovexattr",
+				"fsetxattr",
+				"fstat",
+				"fstat64",
+				"fstatat64",
+				"fstatfs",
+				"fstatfs64",
+				"fsync",
+				"ftruncate",
+				"ftruncate64",
+				"futex",
+				"futex_requeue",
+				"futex_time64",
+				"futex_wait",
+				"futex_waitv",
+				"futex_wake",
+				"futimesat",
+				"getcpu",
+				"getcwd",
+				"getdents",
+				"getdents64",
+				"getegid",
+				"getegid32",
+				"geteuid",
+				"geteuid32",
+				"getgid",
+				"getgid32",
+				"getgroups",
+				"getgroups32",
+				"getitimer",
+				"getpeername",
+				"getpgid",
+				"getpgrp",
+				"getpid",
+				"getppid",
+				"getpriority",
+				"getrandom",
+				"getresgid",
+				"getresgid32",
+				"getresuid",
+				"getresuid32",
+				"getrlimit",
+				"get_robust_list",
+				"getrusage",
+				"getsid",
+				"getsockname",
+				"getsockopt",
+				"get_thread_area",
+				"gettid",
+				"gettimeofday",
+				"getuid",
+				"getuid32",
+				"getxattr",
+				"inotify_add_watch",
+				"inotify_init",
+				"inotify_init1",
+				"inotify_rm_watch",
+				"io_cancel",
+				"ioctl",
+				"io_destroy",
+				"io_getevents",
+				"io_pgetevents",
+				"io_pgetevents_time64",
+				"ioprio_get",
+				"ioprio_set",
+				"io_setup",
+				"io_submit",
+				"ipc",
+				"kill",
+				"landlock_add_rule",
+				"landlock_create_ruleset",
+				"landlock_restrict_self",
+				"lchown",
+				"lchown32",
+				"lgetxattr",
+				"link",
+				"linkat",
+				"listen",
+				"listxattr",
+				"llistxattr",
+				"_llseek",
+				"lremovexattr",
+				"lseek",
+				"lsetxattr",
+				"lstat",
+				"lstat64",
+				"madvise",
+				"map_shadow_stack",
+				"membarrier",
+				"memfd_create",
+				"memfd_secret",
+				"mincore",
+				"mkdir",
+				"mkdirat",
+				"mknod",
+				"mknodat",
+				"mlock",
+				"mlock2",
+				"mlockall",
+				"mmap",
+				"mmap2",
+				"mprotect",
+				"mq_getsetattr",
+				"mq_notify",
+				"mq_open",
+				"mq_timedreceive",
+				"mq_timedreceive_time64",
+				"mq_timedsend",
+				"mq_timedsend_time64",
+				"mq_unlink",
+				"mremap",
+				"msgctl",
+				"msgget",
+				"msgrcv",
+				"msgsnd",
+				"msync",
+				"munlock",
+				"munlockall",
+				"munmap",
+				"name_to_handle_at",
+				"nanosleep",
+				"newfstatat",
+				"_newselect",
+				"open",
+				"openat",
+				"openat2",
+				"pause",
+				"pidfd_open",
+				"pidfd_send_signal",
+				"pipe",
+				"pipe2",
+				"pkey_alloc",
+				"pkey_free",
+				"pkey_mprotect",
+				"poll",
+				"ppoll",
+				"ppoll_time64",
+				"prctl",
+				"pread64",
+				"preadv",
+				"preadv2",
+				"prlimit64",
+				"process_mrelease",
+				"pselect6",
+				"pselect6_time64",
+				"pwrite64",
+				"pwritev",
+				"pwritev2",
+				"read",
+				"readahead",
+				"readlink",
+				"readlinkat",
+				"readv",
+				"recv",
+				"recvfrom",
+				"recvmmsg",
+				"recvmmsg_time64",
+				"recvmsg",
+				"remap_file_pages",
+				"removexattr",
+				"rename",
+				"renameat",
+				"renameat2",
+				"restart_syscall",
+				"rmdir",
+				"rseq",
+				"rt_sigaction",
+				"rt_sigpending",
+				"rt_sigprocmask",
+				"rt_sigqueueinfo",
+				"rt_sigreturn",
+				"rt_sigsuspend",
+				"rt_sigtimedwait",
+				"rt_sigtimedwait_time64",
+				"rt_tgsigqueueinfo",
+				"sched_getaffinity",
+				"sched_getattr",
+				"sched_getparam",
+				"sched_get_priority_max",
+				"sched_get_priority_min",
+				"sched_getscheduler",
+				"sched_rr_get_interval",
+				"sched_rr_get_interval_time64",
+				"sched_setaffinity",
+				"sched_setattr",
+				"sched_setparam",
+				"sched_setscheduler",
+				"sched_yield",
+				"seccomp",
+				"select",
+				"semctl",
+				"semget",
+				"semop",
+				"semtimedop",
+				"semtimedop_time64",
+				"send",
+				"sendfile",
+				"sendfile64",
+				"sendmmsg",
+				"sendmsg",
+				"sendto",
+				"setfsgid",
+				"setfsgid32",
+				"setfsuid",
+				"setfsuid32",
+				"setgid",
+				"setgid32",
+				"setgroups",
+				"setgroups32",
+				"setitimer",
+				"setpgid",
+				"setpriority",
+				"setregid",
+				"setregid32",
+				"setresgid",
+				"setresgid32",
+				"setresuid",
+				"setresuid32",
+				"setreuid",
+				"setreuid32",
+				"setrlimit",
+				"set_robust_list",
+				"setsid",
+				"setsockopt",
+				"set_thread_area",
+				"set_tid_address",
+				"setuid",
+				"setuid32",
+				"setxattr",
+				"shmat",
+				"shmctl",
+				"shmdt",
+				"shmget",
+				"shutdown",
+				"sigaltstack",
+				"signalfd",
+				"signalfd4",
+				"sigprocmask",
+				"sigreturn",
+				"socketcall",
+				"socketpair",
+				"splice",
+				"stat",
+				"stat64",
+				"statfs",
+				"statfs64",
+				"statx",
+				"symlink",
+				"symlinkat",
+				"sync",
+				"sync_file_range",
+				"syncfs",
+				"sysinfo",
+				"tee",
+				"tgkill",
+				"time",
+				"timer_create",
+				"timer_delete",
+				"timer_getoverrun",
+				"timer_gettime",
+				"timer_gettime64",
+				"timer_settime",
+				"timer_settime64",
+				"timerfd_create",
+				"timerfd_gettime",
+				"timerfd_gettime64",
+				"timerfd_settime",
+				"timerfd_settime64",
+				"times",
+				"tkill",
+				"truncate",
+				"truncate64",
+				"ugetrlimit",
+				"umask",
+				"uname",
+				"unlink",
+				"unlinkat",
+				"utime",
+				"utimensat",
+				"utimensat_time64",
+				"utimes",
+				"vfork",
+				"vmsplice",
+				"wait4",
+				"waitid",
+				"waitpid",
+				"write",
+				"writev"
+			],
+			"action": "SCMP_ACT_ALLOW"
+		},
+		{
+			"names": [
+				"process_vm_readv",
+				"process_vm_writev",
+				"ptrace"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"includes": {
+				"minKernel": "4.8"
+			}
+		},
+		{
+			"names": [
+				"socket"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [
+				{
+					"index": 0,
+					"value": 40,
+					"op": "SCMP_CMP_NE"
+				}
+			]
+		},
+		{
+			"names": [
+				"personality"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [
+				{
+					"index": 0,
+					"value": 0,
+					"op": "SCMP_CMP_EQ"
+				}
+			]
+		},
+		{
+			"names": [
+				"personality"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [
+				{
+					"index": 0,
+					"value": 8,
+					"op": "SCMP_CMP_EQ"
+				}
+			]
+		},
+		{
+			"names": [
+				"personality"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [
+				{
+					"index": 0,
+					"value": 131072,
+					"op": "SCMP_CMP_EQ"
+				}
+			]
+		},
+		{
+			"names": [
+				"personality"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [
+				{
+					"index": 0,
+					"value": 131080,
+					"op": "SCMP_CMP_EQ"
+				}
+			]
+		},
+		{
+			"names": [
+				"personality"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [
+				{
+					"index": 0,
+					"value": 4294967295,
+					"op": "SCMP_CMP_EQ"
+				}
+			]
+		},
+		{
+			"names": [
+				"sync_file_range2",
+				"swapcontext"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"includes": {
+				"arches": [
+					"ppc64le"
+				]
+			}
+		},
+		{
+			"names": [
+				"arm_fadvise64_64",
+				"arm_sync_file_range",
+				"sync_file_range2",
+				"breakpoint",
+				"cacheflush",
+				"set_tls"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"includes": {
+				"arches": [
+					"arm",
+					"arm64"
+				]
+			}
+		},
+		{
+			"names": [
+				"arch_prctl"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"includes": {
+				"arches": [
+					"amd64",
+					"x32"
+				]
+			}
+		},
+		{
+			"names": [
+				"modify_ldt"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"includes": {
+				"arches": [
+					"amd64",
+					"x32",
+					"x86"
+				]
+			}
+		},
+		{
+			"names": [
+				"s390_pci_mmio_read",
+				"s390_pci_mmio_write",
+				"s390_runtime_instr"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"includes": {
+				"arches": [
+					"s390",
+					"s390x"
+				]
+			}
+		},
+		{
+			"names": [
+				"riscv_flush_icache"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"includes": {
+				"arches": [
+					"riscv64"
+				]
+			}
+		},
+		{
+			"names": [
+				"open_by_handle_at"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"includes": {
+				"caps": [
+					"CAP_DAC_READ_SEARCH"
+				]
+			}
+		},
+		{
+			"names": [
+				"bpf",
+				"clone",
+				"clone3",
+				"fanotify_init",
+				"fsconfig",
+				"fsmount",
+				"fsopen",
+				"fspick",
+				"lookup_dcookie",
+				"mount",
+				"mount_setattr",
+				"move_mount",
+				"open_tree",
+				"perf_event_open",
+				"quotactl",
+				"quotactl_fd",
+				"setdomainname",
+				"sethostname",
+				"setns",
+				"syslog",
+				"umount",
+				"umount2",
+				"unshare"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"includes": {
+				"caps": [
+					"CAP_SYS_ADMIN"
+				]
+			}
+		},
+		{
+			"names": [
+				"clone"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [
+				{
+					"index": 0,
+					"value": 2114060288,
+					"op": "SCMP_CMP_MASKED_EQ"
+				}
+			],
+			"excludes": {
+				"caps": [
+					"CAP_SYS_ADMIN"
+				],
+				"arches": [
+					"s390",
+					"s390x"
+				]
+			}
+		},
+		{
+			"names": [
+				"clone"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [
+				{
+					"index": 1,
+					"value": 2114060288,
+					"op": "SCMP_CMP_MASKED_EQ"
+				}
+			],
+			"comment": "s390 parameter ordering for clone is different",
+			"includes": {
+				"arches": [
+					"s390",
+					"s390x"
+				]
+			},
+			"excludes": {
+				"caps": [
+					"CAP_SYS_ADMIN"
+				]
+			}
+		},
+		{
+			"names": [
+				"clone3"
+			],
+			"action": "SCMP_ACT_ERRNO",
+			"errnoRet": 38,
+			"excludes": {
+				"caps": [
+					"CAP_SYS_ADMIN"
+				]
+			}
+		},
+		{
+			"names": [
+				"reboot"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"includes": {
+				"caps": [
+					"CAP_SYS_BOOT"
+				]
+			}
+		},
+		{
+			"names": [
+				"chroot"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"includes": {
+				"caps": [
+					"CAP_SYS_CHROOT"
+				]
+			}
+		},
+		{
+			"names": [
+				"delete_module",
+				"init_module",
+				"finit_module"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"includes": {
+				"caps": [
+					"CAP_SYS_MODULE"
+				]
+			}
+		},
+		{
+			"names": [
+				"acct"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"includes": {
+				"caps": [
+					"CAP_SYS_PACCT"
+				]
+			}
+		},
+		{
+			"names": [
+				"kcmp",
+				"pidfd_getfd",
+				"process_madvise",
+				"process_vm_readv",
+				"process_vm_writev",
+				"ptrace"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"includes": {
+				"caps": [
+					"CAP_SYS_PTRACE"
+				]
+			}
+		},
+		{
+			"names": [
+				"iopl",
+				"ioperm"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"includes": {
+				"caps": [
+					"CAP_SYS_RAWIO"
+				]
+			}
+		},
+		{
+			"names": [
+				"settimeofday",
+				"stime",
+				"clock_settime",
+				"clock_settime64"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"includes": {
+				"caps": [
+					"CAP_SYS_TIME"
+				]
+			}
+		},
+		{
+			"names": [
+				"vhangup"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"includes": {
+				"caps": [
+					"CAP_SYS_TTY_CONFIG"
+				]
+			}
+		},
+		{
+			"names": [
+				"get_mempolicy",
+				"mbind",
+				"set_mempolicy",
+				"set_mempolicy_home_node"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"includes": {
+				"caps": [
+					"CAP_SYS_NICE"
+				]
+			}
+		},
+		{
+			"names": [
+				"syslog"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"includes": {
+				"caps": [
+					"CAP_SYSLOG"
+				]
+			}
+		},
+		{
+			"names": [
+				"bpf"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"includes": {
+				"caps": [
+					"CAP_BPF"
+				]
+			}
+		},
+		{
+			"names": [
+				"perf_event_open"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"includes": {
+				"caps": [
+					"CAP_PERFMON"
+				]
+			}
+		}
+	]
+}

--- a/proxy/Caddyfile
+++ b/proxy/Caddyfile
@@ -1,0 +1,6 @@
+# proxy/Caddyfile -- Phase 3 : proxy public minimal (relais HTTP simple).
+# Seul point expose ; Moodle reste sur des reseaux internes (aucun egress).
+# Phase 4 : ajout de TLS + WAF Coraza (OWASP CRS) devant ce reverse_proxy.
+:8080 {
+	reverse_proxy moodle:8080
+}

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -1,0 +1,6 @@
+# proxy/Dockerfile -- Caddy proxy public (Phase 3 : relais simple, durci).
+# Phase 4 : recompilation avec le module WAF Coraza (xcaddy) + TLS.
+FROM caddy:2.8@sha256:226d1f059b75399fe19182893c7184591c07b97afc8dfcf44eeb80c9a77a530f
+# Retire la file-capability du binaire (incompatible no-new-privileges) ; le proxy
+# ecoute sur le port non privilegie 8080.
+RUN cp /usr/bin/caddy /usr/bin/caddy.nocap && rm /usr/bin/caddy && mv /usr/bin/caddy.nocap /usr/bin/caddy


### PR DESCRIPTION
Objectif

Appliquer les mesures de durcissement du Tableau 8 (non-root, lecture seule, no-new-privileges, seccomp, cap_drop: ALL, images épinglées par digest, limites CPU/mémoire), isoler strictement les réseaux internes, et garantir l'absence de flux  sortant (axe confidentialité du chapitre 6).

Contenu

- Chaîne d'approvisionnement : les 5 images épinglées par digest SHA-256 (compose + Dockerfiles).
- Durcissement par conteneur :
- moodle : non-root (uid 33), Apache sur port 8080 (non privilégié), read_only + tmpfs, cap_drop: ALL,  no-new-privileges.
- ollama : non-root (uid 1000), seccomp (profil Docker par défaut, épinglé), read_only + tmpfs, cap_drop: ALL, OLLAMA_KEEP_ALIVE=24h, NUM_PARALLEL=1, limites 2 vCPU / 3 Go.
- db (MariaDB) : no-new-privileges, cap_drop: ALL (+ CHOWN/SETUID/SETGID/DAC_OVERRIDE requis), read_only + tmpfs.
- ollama-gate / proxy (Caddy) : read_only + tmpfs, cap_drop: ALL, no-new-privileges (file-capability retirée du binaire  pour compatibilité).
- mem_limit sur moodle/db/gate/proxy (anti-OOM sur l'hôte 8 Go).
- Modèle épinglé par blob : tuteur-secure construit avec FROM …/blobs/sha256-633fc5be… (intégrité, §5.4), gabarit de chat  préservé.
- Isolation réseau stricte : ai, backend, dmz en internal: true ; seul edge a Internet. Un proxy Caddy minimal (relais est introduit sur edge pour préserver l'accès à Moodle sans lui donner de route sortante (TLS + WAF Coraza = Phase 4).

Vérifications (EC2 Ubuntu, 2 vCPU / 8 Go)

- 5 services démarrés ; login Moodle via le proxy = HTTP 200 ; tuteur répond de bout en bout sous pile durcie+isolée.
- Axe confidentialité : moodle et ollama = NO EGRESS ; proxy = egress (seul point edge). Non-fuite des données garantie par la topologie.
- db healthy sous durcissement ; gate 401/relais OK ; ollama non-root + read-only sert l'inférence.
- Performance : KEEP_ALIVE → ~7-8 s à chaud (vs ~48 s à froid). Sécurité : garde-fous inchangés → pas de régression (98 %  en Phase 2).

Revue (Opus) — triage

- Aucun Critical. Topologie et confidentialité correctes.
- I1 (ollama sans read-only) → corrigé. M3 (pas de limite mémoire) → corrigé. M4 (DAC_OVERRIDE db) → testé : requis, conservé.
- M1 (seccomp = profil par défaut, durcissement neutre), M2 (tmpfs noexec non exposé par Compose), M5 (sessions/logs tmpfs volatils) → documentés dans eval/RESULTS-phase3.md.

Caveats

- Instance réelle 2 vCPU / 8 Go (t3.large), pas 4/16 → cpus 2.0, latence loin de la cible <2 s (compromis matériel assumé).
- Provisionnement du modèle : ai étant internal, un nouveau pull suppose d'attacher temporairement Ollama à un réseau à egress.

Reporté

Phase 4 : TLS + WAF Coraza (OWASP CRS) sur le proxy edge. Puis Phase 5 (IoT/MQTT), Phase 6 (Falco), Phase 7 (campagne d'évaluation 3 axes).