### PR TITLE
Phase 4 — Proxy public : TLS + WAF Coraza (OWASP CRS)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
 # Nom de projet Compose
 COMPOSE_PROJECT_NAME=aimoodle
 # URL publique Moodle (phase 1 : accès direct via tunnel SSH)
-MOODLE_WWWROOT=http://localhost:8080
+MOODLE_WWWROOT=https://localhost

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,12 +88,13 @@ services:
       db: { condition: service_healthy }
       ollama-gate: { condition: service_started }
   proxy:
-    build: ./proxy                       # Caddy relais (Phase 4 : +WAF Coraza +TLS)
+    build: ./proxy                       # Caddy + WAF Coraza (OWASP CRS) + TLS
     networks: [edge, dmz]
-    ports: ["8080:8080"]                 # seul point expose
+    ports: ["443:443", "80:80"]          # seul point expose (HTTPS + redirection)
     volumes: ["./proxy/Caddyfile:/etc/caddy/Caddyfile:ro"]
     security_opt: [no-new-privileges:true]
     cap_drop: [ALL]
+    cap_add: [NET_BIND_SERVICE]          # bind 443/80 sous cap_drop ALL + no-new-privileges
     read_only: true
     tmpfs: [/tmp, /config, /data]
     mem_limit: 256m

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,7 +90,7 @@ services:
   proxy:
     build: ./proxy                       # Caddy + WAF Coraza (OWASP CRS) + TLS
     networks: [edge, dmz]
-    ports: ["443:443", "80:80"]          # seul point expose (HTTPS + redirection)
+    ports: ["443:443"]                   # seul point expose (HTTPS)
     volumes: ["./proxy/Caddyfile:/etc/caddy/Caddyfile:ro"]
     security_opt: [no-new-privileges:true]
     cap_drop: [ALL]

--- a/docs/superpowers/plans/2026-07-02-phase4-waf-tls.md
+++ b/docs/superpowers/plans/2026-07-02-phase4-waf-tls.md
@@ -1,0 +1,217 @@
+# Phase 4 — Proxy public : TLS + WAF Coraza (OWASP CRS) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Transformer le proxy relais minimal (Phase 3) en véritable point d'entrée durci : TLS (autorité interne de Caddy, repli hors-ligne) et pare-feu applicatif **Coraza** chargé de l'**OWASP Core Rule Set** en mode bloquant, devant Moodle.
+
+**Architecture :** L'image `proxy` est recompilée avec `xcaddy --with coraza-caddy/v2` (WAF). Le Caddyfile public termine le TLS (`tls internal`), applique le WAF (CRS, `SecRuleEngine On`) puis relaie vers `moodle:8080`. Moodle passe derrière SSL (`$CFG->sslproxy`). Le CRS est ensuite affiné pour ne pas bloquer le trafic Moodle légitime.
+
+**Tech Stack :** Caddy 2.8 + xcaddy, `github.com/corazawaf/coraza-caddy/v2` (OWASP CRS embarqué), TLS interne, Moodle `sslproxy`.
+
+## Global Constraints
+
+- Exécution/test sur l'**EC2 Ubuntu** `ec2-13-53-187-154...` (clé `E:\EC2\MoodleKey.pem`). **Sous-agents : authoring LOCAL ; contrôleur = EC2.** EC2 sur la branche `phase4-waf-tls` (checkout par le contrôleur).
+- **Aucun assouplissement sécurité.** Pas de trailer `Co-Authored-By`.
+- Instance 2 vCPU / 8 Go. Le proxy reste durci (Phase 3 : `read_only`, tmpfs, `cap_drop: ALL`, `no-new-privileges`, fscap retirée).
+- **Digests épinglés (verbatim) :**
+  - builder : `caddy:2.8-builder@sha256:9f86856dd089cd85f546b6a022079c9f157ab62bc1d688ecd9b5d474ea81a487`
+  - runtime : `caddy:2.8@sha256:226d1f059b75399fe19182893c7184591c07b97afc8dfcf44eeb80c9a77a530f`
+- **Module WAF :** `github.com/corazawaf/coraza-caddy/v2` (embarque l'OWASP CRS ; directive `load_owasp_crs`).
+- **Le WAF CRS en mode bloquant génère des faux positifs sur Moodle** (formulaires POST riches) — la Task 4 (tuning) est **itérative** : login et actions Moodle doivent rester fonctionnels, WAF activé.
+
+---
+
+### Task 1: Recompiler l'image proxy avec le WAF Coraza (xcaddy)
+
+**Files:**
+- Modify: `proxy/Dockerfile`
+
+**Interfaces:**
+- Produces: image `proxy` = Caddy compilé avec `coraza-caddy/v2`, fscap retirée, durcie.
+
+- [ ] **Step 1: `proxy/Dockerfile` multi-étapes**
+
+```dockerfile
+# proxy/Dockerfile -- Caddy public compile avec le WAF Coraza (OWASP CRS).
+FROM caddy:2.8-builder@sha256:9f86856dd089cd85f546b6a022079c9f157ab62bc1d688ecd9b5d474ea81a487 AS build
+RUN xcaddy build \
+    --with github.com/corazawaf/coraza-caddy/v2
+
+FROM caddy:2.8@sha256:226d1f059b75399fe19182893c7184591c07b97afc8dfcf44eeb80c9a77a530f
+COPY --from=build /usr/bin/caddy /usr/bin/caddy
+# Retire la file-capability (incompatible no-new-privileges). Le proxy ecoutera
+# sur 443 : la capacite de bind sera accordee par cap_add NET_BIND_SERVICE (compose).
+RUN cp /usr/bin/caddy /usr/bin/caddy.nocap && rm /usr/bin/caddy && mv /usr/bin/caddy.nocap /usr/bin/caddy
+```
+
+- [ ] **Step 2 (CONTRÔLEUR): builder + vérifier le module**
+
+Run: `docker compose build proxy` (télécharge les modules Go — le build a Internet via l'hôte).
+Puis : `docker compose run --rm --entrypoint caddy proxy list-modules 2>/dev/null | grep -i coraza`
+Expected: `http.handlers.coraza_waf` listé.
+
+- [ ] **Step 3: Commit** — `git commit -m "feat(proxy): compile Caddy with Coraza WAF module (xcaddy)"` ; push.
+
+---
+
+### Task 2: Caddyfile public — TLS interne + WAF CRS + reverse_proxy
+
+**Files:**
+- Modify: `proxy/Caddyfile`
+- Modify: `docker-compose.yml` (proxy : ports 443/80, `cap_add: NET_BIND_SERVICE`)
+
+**Interfaces:**
+- Consumes: image proxy avec Coraza (Task 1).
+- Produces: proxy en **HTTPS (443)**, TLS interne, WAF CRS en mode bloquant, relais vers `moodle:8080`.
+
+- [ ] **Step 1: `proxy/Caddyfile`**
+
+```caddyfile
+{
+	order coraza_waf first
+}
+
+:443 {
+	tls internal
+
+	coraza_waf {
+		load_owasp_crs
+		directives `
+			Include @coraza.conf-recommended
+			Include @crs-setup.conf.example
+			Include @owasp_crs/*.conf
+			SecRuleEngine On
+		`
+	}
+
+	reverse_proxy moodle:8080
+}
+```
+> `:443` (sans nom d'hôte) sert le TLS interne pour tout hôte (accès démo par tunnel SSH sur
+> `https://localhost`). En production, remplacer par `https://lms.etablissement.cm` + certificat PKI.
+
+- [ ] **Step 2: Ajuster le service `proxy` (compose)**
+
+Remplacer `ports: ["8080:8080"]` par `ports: ["443:443", "80:80"]` et ajouter la capacité de bind
+des ports privilégiés (compatible avec `cap_drop: ALL` + `no-new-privileges`) :
+```yaml
+    cap_drop: [ALL]
+    cap_add: [NET_BIND_SERVICE]
+```
+(Conserver `read_only`, `tmpfs`, `mem_limit`, `security_opt`, le montage du Caddyfile, `depends_on`.)
+
+- [ ] **Step 3 (CONTRÔLEUR): déployer** — `docker compose up -d proxy` ; le proxy démarre et écoute
+  sur 443. (L'accès Moodle sera vérifié en Task 3, après bascule SSL de Moodle.)
+
+- [ ] **Step 4: Commit** — `git commit -m "feat(proxy): TLS internal + Coraza OWASP CRS (SecRuleEngine On)"` ; push.
+
+---
+
+### Task 3: Moodle derrière le proxy SSL
+
+**Files:**
+- Modify: `moodle/config.php` (`sslproxy`)
+- Modify: `.env.example` (`MOODLE_WWWROOT` en https) + `.env` (contrôleur, sur l'EC2)
+
+**Interfaces:**
+- Consumes: proxy HTTPS (Task 2).
+- Produces: Moodle servi en **HTTPS via le proxy**, URLs cohérentes.
+
+- [ ] **Step 1: `config.php` — proxy SSL**
+
+Ajouter avant `require_once(...setup.php)` :
+```php
+$CFG->sslproxy = 1; // TLS termine par le proxy Caddy ; trafic interne en HTTP.
+```
+
+- [ ] **Step 2: `.env.example` — wwwroot https**
+
+```dotenv
+MOODLE_WWWROOT=https://localhost
+```
+
+- [ ] **Step 3 (CONTRÔLEUR): mettre à jour `.env` sur l'EC2 + rebuild + purge**
+
+```bash
+sed -i 's#^MOODLE_WWWROOT=.*#MOODLE_WWWROOT=https://localhost#' .env
+docker compose build moodle && docker compose up -d moodle
+docker compose exec -T moodle php admin/cli/cfg.php --name=wwwroot --set=https://localhost 2>/dev/null || true
+docker compose exec -T moodle php admin/cli/purge_caches.php
+```
+
+- [ ] **Step 4 (CONTRÔLEUR): vérifier l'accès HTTPS via le proxy**
+
+Run (via l'EC2, en acceptant le certificat auto-signé) :
+```bash
+curl -k -sS -o /dev/null -w "HTTPS login: %{http_code}\n" https://localhost/login/index.php
+```
+Expected: `200` (ou `303`/redirection cohérente). Consigner.
+
+- [ ] **Step 5: Commit** — `git commit -m "feat(moodle): run behind SSL proxy (sslproxy, https wwwroot)"` ; push.
+
+---
+
+### Task 4 (CONTRÔLEUR + ITÉRATIF): Tuning CRS pour Moodle
+
+**Files:**
+- Modify: `proxy/Caddyfile` (exclusions / niveau de paranoïa)
+
+**Interfaces:**
+- Produces: WAF **actif et bloquant** qui laisse passer le trafic Moodle légitime.
+
+- [ ] **Step 1: Établir la base de faux positifs**
+
+Se connecter réellement à Moodle (login admin + navigation) via HTTPS et relever les requêtes
+bloquées à tort (HTTP 403 du WAF) dans les logs du proxy :
+```bash
+docker compose logs proxy 2>&1 | grep -iE "coraza|denied|403" | tail -30
+```
+
+- [ ] **Step 2: Ajouter les exclusions ciblées (itératif)**
+
+Dans le bloc `directives` du Caddyfile, AVANT `Include @owasp_crs/*.conf`, réduire les faux
+positifs par un niveau de paranoïa bas et/ou des exclusions de règles par ID observées :
+```
+SecAction "id:900000,phase:1,nolog,pass,setvar:tx.paranoia_level=1"
+# Exclusions ciblees (exemples, a renseigner selon les 403 observes) :
+# SecRuleRemoveById 942100
+# SecRuleUpdateTargetById 932130 "!ARGS:sesskey"
+```
+Rebuild non nécessaire (Caddyfile monté en volume) : `docker compose restart proxy`. Répéter
+jusqu'à ce que login + actions Moodle passent, **WAF toujours en `SecRuleEngine On`**.
+
+- [ ] **Step 3: Vérifier que le WAF bloque toujours une attaque**
+
+Le WAF doit continuer à bloquer une attaque applicative évidente :
+```bash
+curl -k -sS -o /dev/null -w "SQLi probe: %{http_code}\n" "https://localhost/login/index.php?id=1%27%20OR%20%271%27=%271"
+curl -k -sS -o /dev/null -w "XSS probe: %{http_code}\n" "https://localhost/?q=<script>alert(1)</script>"
+```
+Expected: `403` (bloqué par le CRS) pour au moins ces sondes, tandis que le login légitime = 200.
+
+- [ ] **Step 4: Commit** — `git commit -m "tune(proxy): CRS exclusions so Moodle works with WAF blocking on"` ; push.
+
+---
+
+### Task 5 (CONTRÔLEUR): Évaluation Phase 4
+
+**Files:** `eval/RESULTS-phase4.md`
+
+- [ ] **Step 1: Consigner** dans `eval/RESULTS-phase4.md` : TLS actif (cert interne), WAF CRS
+  bloquant, exclusions Moodle appliquées, sondes SQLi/XSS bloquées (403) vs login légitime (200),
+  tuteur toujours fonctionnel de bout en bout, confidentialité inchangée (Moodle/Ollama no egress).
+- [ ] **Step 2: Commit** — `git commit -m "docs(eval): phase 4 results (TLS + WAF CRS blocking)"` ; push.
+
+## Critères de fin de phase 4
+
+- [ ] Image proxy compilée avec le module `coraza_waf`.
+- [ ] Proxy en HTTPS (TLS interne) ; Moodle accessible via HTTPS derrière le proxy (login 200).
+- [ ] WAF CRS en `SecRuleEngine On` : sondes SQLi/XSS bloquées (403), trafic Moodle légitime OK.
+- [ ] Tuteur fonctionnel ; confidentialité (no egress) et durcissement Phase 3 préservés.
+
+## Notes / reporté
+- TLS : autorité interne de Caddy (repli hors-ligne). En production : certificat de la PKI de
+  l'établissement (aucune distribution de CA côté client). Documenté.
+- Le tuning CRS livré vise la faisabilité (Moodle fonctionne, WAF bloquant) ; un durcissement fin
+  par montée de paranoïa relève de la mise en production.
+- IoT/MQTT = Phase 5 ; Falco = Phase 6 ; campagne d'évaluation 3 axes = Phase 7.

--- a/eval/RESULTS-phase4.md
+++ b/eval/RESULTS-phase4.md
@@ -1,0 +1,51 @@
+# Résultats d'évaluation — Phase 4 (TLS + WAF Coraza)
+
+Évaluation de fin de Phase 4. Le proxy public devient un véritable point d'entrée durci : TLS
+(autorité interne) + pare-feu applicatif **Coraza** chargé de l'**OWASP Core Rule Set** en mode
+bloquant, devant Moodle. EC2 Ubuntu, 2 vCPU / 8 Go.
+
+## WAF OWASP CRS — mode bloquant (`SecRuleEngine On`)
+
+Proxy = Caddy 2.11.2 recompilé avec `github.com/corazawaf/coraza-caddy/v2` (OWASP CRS **4.25.0**,
+paranoia level 1, scoring d'anomalie). Sondes depuis l'hôte via HTTPS :
+
+| Requête | Code | Attendu |
+|---|---|---|
+| `GET /login/index.php` (légitime) | **200** | passe ✅ |
+| `GET /` (accueil) | **200** | passe ✅ |
+| `POST /login` (logintoken + username + mot de passe à caractères spéciaux) | **303** | passe ✅ |
+| `GET /course/view.php?id=1` | **303** | passe ✅ |
+| **SQLi** `?id=1' OR '1'='1` | **403** | bloqué ✅ (règles 942xxx) |
+| **XSS** `?q=<script>alert(1)</script>` | **403** | bloqué ✅ (941160, 941390 → score 20) |
+| **Path traversal** `?f=../../../../etc/passwd` | **403** | bloqué ✅ (930100/120, 932160 → score 40) |
+
+Aucun **faux positif** journalisé sur le trafic Moodle légitime (login, POST, navigation) au
+paranoia level 1. Le tuning fin (montée de paranoïa, exclusions par règle) reste une itération de
+production ; il n'a pas été nécessaire pour les flux de démonstration.
+
+## TLS
+- `tls internal` : Caddy émet un certificat auto-signé (autorité interne) pour l'hôte `localhost`.
+  Accès démo par tunnel SSH sur `https://localhost` (avertissement de certificat attendu).
+- L'installation du certificat racine dans le magasin système du conteneur échoue (conteneur durci
+  read-only/sans `certutil`) — **sans effet** : le certificat est bien généré et servi.
+- Production : certificat de la PKI de l'établissement (aucune distribution de CA côté client).
+
+## Moodle derrière le proxy SSL
+- `$CFG->sslproxy = 1`, `wwwroot = https://localhost` : Moodle génère des URLs HTTPS ; le TLS est
+  terminé par le proxy, le trafic proxy→moodle reste en HTTP sur le réseau interne `dmz`.
+- Login accessible en **HTTPS via le proxy** (200).
+
+## Non-régression
+- Tuteur toujours fonctionnel de bout en bout (~3-4 s à chaud) — le chemin d'inférence est interne
+  (moodle→gate→ollama), non affecté par le WAF (qui inspecte les requêtes entrantes).
+- Confidentialité inchangée : `moodle` et `ollama` = **NO EGRESS**.
+
+## Note d'implémentation (versions)
+Le module `coraza-caddy/v2` récent impose un couplage strict de version avec Caddy : v2.5.0 exige
+Caddy **2.11.2** et Go ≥ 1.25. Le proxy est donc bâti sur la chaîne **Caddy 2.11.2** (builder Go
+1.26), tandis que le reste de la pile reste sur Caddy 2.8. Images builder et runtime épinglées par
+digest.
+
+## Reporté
+- Tuning CRS de production (paranoia + exclusions Moodle fines) selon l'usage réel.
+- IoT/MQTT = Phase 5 ; Falco = Phase 6 ; campagne d'évaluation 3 axes = Phase 7.

--- a/moodle/config.php
+++ b/moodle/config.php
@@ -10,7 +10,8 @@ $CFG->dbuser    = 'moodle';
 $CFG->dbpass    = trim(file_get_contents('/run/secrets/db_password'));
 $CFG->prefix    = 'mdl_';
 $CFG->dboptions = ['dbport' => 3306, 'dbsocket' => '', 'dbcollation' => 'utf8mb4_unicode_ci'];
-$CFG->wwwroot   = getenv('MOODLE_WWWROOT') ?: 'http://localhost:8080';
+$CFG->wwwroot   = getenv('MOODLE_WWWROOT') ?: 'https://localhost';
+$CFG->sslproxy  = 1; // TLS termine par le proxy Caddy ; trafic proxy->moodle en HTTP.
 $CFG->dataroot  = '/var/www/moodledata';
 $CFG->admin     = 'admin';
 $CFG->directorypermissions = 02777;

--- a/proxy/Caddyfile
+++ b/proxy/Caddyfile
@@ -1,6 +1,23 @@
-# proxy/Caddyfile -- Phase 3 : proxy public minimal (relais HTTP simple).
+# proxy/Caddyfile -- proxy public : TLS interne + WAF Coraza (OWASP CRS).
 # Seul point expose ; Moodle reste sur des reseaux internes (aucun egress).
-# Phase 4 : ajout de TLS + WAF Coraza (OWASP CRS) devant ce reverse_proxy.
-:8080 {
+{
+	order coraza_waf first
+}
+
+:443 {
+	# Repli hors-ligne : autorite interne de Caddy (cert auto-signe).
+	# Production : certificat de la PKI de l'etablissement.
+	tls internal
+
+	coraza_waf {
+		load_owasp_crs
+		directives `
+			Include @coraza.conf-recommended
+			Include @crs-setup.conf.example
+			Include @owasp_crs/*.conf
+			SecRuleEngine On
+		`
+	}
+
 	reverse_proxy moodle:8080
 }

--- a/proxy/Caddyfile
+++ b/proxy/Caddyfile
@@ -4,9 +4,10 @@
 	order coraza_waf first
 }
 
-:443 {
+localhost {
+	# Site nomme -> Caddy emet un cert interne pour cet hote (SNI). Demo : acces
+	# par tunnel SSH sur https://localhost. Production : lms.etablissement.cm + PKI.
 	# Repli hors-ligne : autorite interne de Caddy (cert auto-signe).
-	# Production : certificat de la PKI de l'etablissement.
 	tls internal
 
 	coraza_waf {

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -1,7 +1,8 @@
 # proxy/Dockerfile -- Caddy public compile avec le WAF Coraza (OWASP CRS).
 FROM caddy:2.8-builder@sha256:9f86856dd089cd85f546b6a022079c9f157ab62bc1d688ecd9b5d474ea81a487 AS build
+# v2.4.0 : derniere version compatible Go 1.23 du builder (v2.5.0 exige Go 1.25).
 RUN xcaddy build \
-    --with github.com/corazawaf/coraza-caddy/v2
+    --with github.com/corazawaf/coraza-caddy/v2@v2.4.0
 
 FROM caddy:2.8@sha256:226d1f059b75399fe19182893c7184591c07b97afc8dfcf44eeb80c9a77a530f
 COPY --from=build /usr/bin/caddy /usr/bin/caddy

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -1,6 +1,10 @@
-# proxy/Dockerfile -- Caddy proxy public (Phase 3 : relais simple, durci).
-# Phase 4 : recompilation avec le module WAF Coraza (xcaddy) + TLS.
+# proxy/Dockerfile -- Caddy public compile avec le WAF Coraza (OWASP CRS).
+FROM caddy:2.8-builder@sha256:9f86856dd089cd85f546b6a022079c9f157ab62bc1d688ecd9b5d474ea81a487 AS build
+RUN xcaddy build \
+    --with github.com/corazawaf/coraza-caddy/v2
+
 FROM caddy:2.8@sha256:226d1f059b75399fe19182893c7184591c07b97afc8dfcf44eeb80c9a77a530f
-# Retire la file-capability du binaire (incompatible no-new-privileges) ; le proxy
-# ecoute sur le port non privilegie 8080.
+COPY --from=build /usr/bin/caddy /usr/bin/caddy
+# Retire la file-capability (incompatible no-new-privileges). Le proxy ecoute sur
+# 443 : la capacite de bind est accordee par cap_add NET_BIND_SERVICE (compose).
 RUN cp /usr/bin/caddy /usr/bin/caddy.nocap && rm /usr/bin/caddy && mv /usr/bin/caddy.nocap /usr/bin/caddy

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -1,11 +1,11 @@
 # proxy/Dockerfile -- Caddy public compile avec le WAF Coraza (OWASP CRS).
-# NB : le module coraza-caddy/v2 recent exige Caddy >= 2.9 et Go >= 1.25 ; on utilise
-# donc la chaine Caddy 2.10 pour le proxy (le reste de la pile reste sur Caddy 2.8).
-FROM caddy:2.10-builder@sha256:01668408cc26e2e00c9d067c30cb43b2ba14ad1f2808beda55503cb2a31f59dc AS build
+# NB : coraza-caddy/v2 v2.5.0 exige exactement Caddy 2.11.2 (Go >= 1.25). On utilise
+# donc la chaine Caddy 2.11.2 pour le proxy ; le reste de la pile reste sur Caddy 2.8.
+FROM caddy:2.11.2-builder@sha256:1ecefa333507828a592aaecc68d5f62a993787057429c04e9b0438a65c980a30 AS build
 RUN xcaddy build \
     --with github.com/corazawaf/coraza-caddy/v2@v2.5.0
 
-FROM caddy:2.10@sha256:c3d7ee5d2b11f9dc54f947f68a734c84e9c9666c92c88a7f30b9cba5da182adb
+FROM caddy:2.11.2@sha256:25cdc846626b62d05f6b633b9b40c2c9f6ef89b515dc76133cefd920f7dbe562
 COPY --from=build /usr/bin/caddy /usr/bin/caddy
 # Retire la file-capability (incompatible no-new-privileges). Le proxy ecoute sur
 # 443 : la capacite de bind est accordee par cap_add NET_BIND_SERVICE (compose).

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -1,8 +1,8 @@
 # proxy/Dockerfile -- Caddy public compile avec le WAF Coraza (OWASP CRS).
 FROM caddy:2.8-builder@sha256:9f86856dd089cd85f546b6a022079c9f157ab62bc1d688ecd9b5d474ea81a487 AS build
-# v2.4.0 : derniere version compatible Go 1.23 du builder (v2.5.0 exige Go 1.25).
+# v2.1.0 : derniere version compatible Go 1.23 du builder (v2.2.0+ exigent Go >= 1.24/1.25).
 RUN xcaddy build \
-    --with github.com/corazawaf/coraza-caddy/v2@v2.4.0
+    --with github.com/corazawaf/coraza-caddy/v2@v2.1.0
 
 FROM caddy:2.8@sha256:226d1f059b75399fe19182893c7184591c07b97afc8dfcf44eeb80c9a77a530f
 COPY --from=build /usr/bin/caddy /usr/bin/caddy

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -1,10 +1,11 @@
 # proxy/Dockerfile -- Caddy public compile avec le WAF Coraza (OWASP CRS).
-FROM caddy:2.8-builder@sha256:9f86856dd089cd85f546b6a022079c9f157ab62bc1d688ecd9b5d474ea81a487 AS build
-# v2.1.0 : derniere version compatible Go 1.23 du builder (v2.2.0+ exigent Go >= 1.24/1.25).
+# NB : le module coraza-caddy/v2 recent exige Caddy >= 2.9 et Go >= 1.25 ; on utilise
+# donc la chaine Caddy 2.10 pour le proxy (le reste de la pile reste sur Caddy 2.8).
+FROM caddy:2.10-builder@sha256:01668408cc26e2e00c9d067c30cb43b2ba14ad1f2808beda55503cb2a31f59dc AS build
 RUN xcaddy build \
-    --with github.com/corazawaf/coraza-caddy/v2@v2.1.0
+    --with github.com/corazawaf/coraza-caddy/v2@v2.5.0
 
-FROM caddy:2.8@sha256:226d1f059b75399fe19182893c7184591c07b97afc8dfcf44eeb80c9a77a530f
+FROM caddy:2.10@sha256:c3d7ee5d2b11f9dc54f947f68a734c84e9c9666c92c88a7f30b9cba5da182adb
 COPY --from=build /usr/bin/caddy /usr/bin/caddy
 # Retire la file-capability (incompatible no-new-privileges). Le proxy ecoute sur
 # 443 : la capacite de bind est accordee par cap_add NET_BIND_SERVICE (compose).


### PR DESCRIPTION
Objectif

Transformer le proxy relais (Phase 3) en point d'entrée durci : TLS (autorité interne, repli hors-ligne) et pare-feu applicatif Coraza chargé de l'OWASP Core Rule Set en mode bloquant, devant Moodle.

Contenu

- proxy/Dockerfile : Caddy recompilé via xcaddy --with github.com/corazawaf/coraza-caddy/v2@v2.5.0 (multi-étapes, images builder/runtime épinglées par digest). Chaîne Caddy 2.11.2 (contrainte de version du module ; reste de la pile en 2.8). File-capability retirée.
- proxy/Caddyfile : site localhost, tls internal, coraza_waf { load_owasp_crs; directives … SecRuleEngine On }, reverse_proxy moodle:8080.
- docker-compose.yml : proxy sur 443 (cap_add: NET_BIND_SERVICE sous cap_drop: ALL + no-new-privileges).
- moodle/config.php + .env : $CFG->sslproxy = 1, wwwroot = https://localhost.

Vérifications (EC2, HTTPS via le proxy)

- Login Moodle HTTPS via proxy = 200 ; trafic légitime (GET /, POST /login avec logintoken, /course) passe (200/303) sans  faux positif (CRS PL1).
- WAF bloque : SQLi (403), XSS (403, règles 941160/941390), path-traversal (403, règles 930/932). CRS 4.25.0, scoring d'anomalie.
- Tuteur fonctionnel (~3-4 s chaud) ; confidentialité inchangée (moodle/ollama = NO EGRESS).

Caveats

- tls internal : certificat auto-signé (avertissement navigateur en démo) ; l'installation du CA racine dans le conteneur  durci échoue sans effet. Production : PKI de l'établissement.
- Tuning CRS fin (paranoïa + exclusions) = itération de production.

Reporté

Phase 5 (IoT/MQTT) · Phase 6 (Falco) · Phase 7 (campagne d'évaluation 3 axes).