### PR TITLE
Phase 6 — Supervision en exécution (Falco) : règles Ollama + calibration

### DIFF
--- a/docs/superpowers/plans/2026-07-02-phase6-falco.md
+++ b/docs/superpowers/plans/2026-07-02-phase6-falco.md
@@ -1,0 +1,153 @@
+# Phase 6 — Supervision en exécution (Falco) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development ou executing-plans. Steps en `- [ ]`.
+
+**Goal:** Concrétiser la supervision runtime annoncée : déployer **Falco** sur l'hôte (eBPF) pour observer les appels système des conteneurs, avec trois règles ciblant le conteneur d'inférence Ollama (processus inattendu, shell, connexion sortante interdite). Démontrer qu'une alerte se déclenche.
+
+**Architecture :** Falco tourne **sur l'hôte EC2** (sonde modern eBPF, noyau 6.17 + BTF présent → CO-RE, aucun module à compiler). Le fichier de règles versionné `falco/falco_rules.local.yaml` (Annexe E) est déployé dans `/etc/falco/`. Les alertes sortent vers le journal (syslog/stdout), destinées à alimenter la journalisation.
+
+**Tech Stack :** Falco (modern_ebpf), règles Falco, EC2 Ubuntu.
+
+## Global Constraints
+
+- Exécution/test sur l'**hôte EC2** (`E:\EC2\MoodleKey.pem`). Falco s'installe **sur l'hôte** (pas dans Compose) — c'est une étape de provisionnement contrôleur (comme Docker en Phase 1). EC2 sur la branche `phase6-falco`.
+- **Aucun assouplissement sécurité.** Pas de `Co-Authored-By`.
+- Falco est le **moniteur de sécurité** : il a légitimement besoin de privilèges noyau (eBPF) — exception assumée au principe « pas de privilèges », car c'est précisément son rôle.
+- Noyau EC2 = 6.17 + `/sys/kernel/btf/vmlinux` présent → pilote **modern_ebpf** (pas de kmod).
+- Le conteneur Ollama a pour image `ollama/ollama` → `container.image.repository contains "ollama"`.
+
+---
+
+### Task 1: Règles Falco ciblant le conteneur Ollama
+
+**Files:**
+- Create: `falco/falco_rules.local.yaml`
+
+**Interfaces:**
+- Produces: 3 règles (Annexe E) chargées par Falco pour le conteneur d'inférence.
+
+- [ ] **Step 1: `falco/falco_rules.local.yaml`**
+
+```yaml
+# falco_rules.local.yaml -- supervision du conteneur d'inference Ollama (Annexe E).
+- macro: ollama_container
+  condition: container.image.repository contains "ollama"
+
+- rule: Ollama - processus inattendu
+  desc: Tout processus autre que le binaire ollama dans le conteneur
+  condition: spawned_process and ollama_container and not proc.name in (ollama, runner)
+  output: >
+    Processus inattendu dans le conteneur Ollama
+    (proc=%proc.name parent=%proc.pname cmd=%proc.cmdline
+     image=%container.image.repository)
+  priority: WARNING
+  tags: [container, llm, mitre_execution]
+
+- rule: Ollama - interpreteur de commandes
+  desc: Un shell est lance dans le conteneur Ollama (exploitation probable)
+  condition: spawned_process and ollama_container and proc.name in (sh, bash, dash, ash, zsh)
+  output: >
+    Shell ouvert dans le conteneur Ollama
+    (shell=%proc.name parent=%proc.pname cmd=%proc.cmdline)
+  priority: CRITICAL
+  tags: [container, llm, shell]
+
+- rule: Ollama - connexion sortante interdite
+  desc: Ollama est isole ; toute sortie reseau signale une exfiltration
+  condition: outbound and ollama_container and not fd.sip in ("127.0.0.1")
+  output: >
+    Connexion sortante depuis le conteneur Ollama
+    (destination=%fd.sip:%fd.sport cmd=%proc.cmdline)
+  priority: CRITICAL
+  tags: [network, llm, exfiltration]
+```
+
+- [ ] **Step 2: Commit** — `git commit -m "feat(falco): runtime rules targeting the ollama container (Annex E)"` ; push.
+
+---
+
+### Task 2 (CONTRÔLEUR): Installer Falco sur l'hôte EC2
+
+**Files:** aucun (provisionnement hôte).
+
+**Interfaces:**
+- Produces: service Falco actif (modern_ebpf), chargé des règles locales.
+
+- [ ] **Step 1: Dépôt Falco + installation non interactive**
+
+Sur l'hôte EC2 :
+```bash
+sudo curl -fsSL https://falco.org/repo/falcosecurity-packages.asc -o /usr/share/keyrings/falco-archive-keyring.asc
+echo "deb [signed-by=/usr/share/keyrings/falco-archive-keyring.asc] https://download.falco.org/packages/deb stable main" | sudo tee /etc/apt/sources.list.d/falcosecurity.list
+sudo apt-get update -qq
+# Installation sans prompt de pilote (on force modern_ebpf ensuite) :
+echo "falco falco/dkms select No" | sudo debconf-set-selections
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y falco
+```
+
+- [ ] **Step 2: Forcer le pilote modern_ebpf + charger les règles locales**
+
+```bash
+sudo sed -ri 's/^\s*kind:.*/  kind: modern_ebpf/' /etc/falco/falco.yaml || true
+# Deployer les regles versionnees :
+sudo cp ~/ai-moodle-security/falco/falco_rules.local.yaml /etc/falco/falco_rules.local.yaml
+```
+
+- [ ] **Step 3: Démarrer le service modern_ebpf**
+
+```bash
+sudo systemctl disable --now falco-bpf falco-kmod 2>/dev/null || true
+sudo systemctl enable --now falco-modern-bpf.service
+sleep 5
+systemctl is-active falco-modern-bpf.service
+sudo journalctl -u falco-modern-bpf -n 15 --no-pager | grep -iE "rules loaded|starting|error|modern"
+```
+Expected : service `active` ; règles chargées sans erreur (dont nos 3 règles Ollama).
+
+---
+
+### Task 3 (CONTRÔLEUR): Déclencher et vérifier une alerte
+
+**Files:** aucun.
+
+**Interfaces:**
+- Produces: preuve qu'une action suspecte dans le conteneur Ollama déclenche l'alerte Falco.
+
+- [ ] **Step 1: Déclencher la règle CRITICAL « shell »**
+
+```bash
+docker compose -f ~/ai-moodle-security/docker-compose.yml exec -T ollama sh -c 'echo test' 2>/dev/null || \
+docker exec aimoodle-ollama-1 sh -c 'echo test'
+sleep 3
+sudo journalctl -u falco-modern-bpf --since "1 min ago" --no-pager | grep -iE "Shell ouvert dans le conteneur Ollama|Ollama"
+```
+Expected : une ligne d'alerte **CRITICAL « Shell ouvert dans le conteneur Ollama »** avec `shell=sh`.
+
+- [ ] **Step 2: (optionnel) Constater le bruit de la règle « processus inattendu »**
+
+Vérifier si des WARNING « Processus inattendu » apparaissent en fonctionnement normal (sous-processus d'inférence) — à consigner comme nécessitant un affinage par exceptions (Annexe E : « l'affinage n'est pas optionnel »).
+
+- [ ] **Step 3: Confirmer que la règle « connexion sortante » reste silencieuse**
+
+En fonctionnement normal (Ollama isolé, aucun egress), aucune alerte de connexion sortante ne doit apparaître — cohérent avec l'isolation réseau de la Phase 3.
+
+---
+
+### Task 4 (CONTRÔLEUR): Évaluation Phase 6
+
+**Files:** `eval/RESULTS-phase6.md`
+
+- [ ] **Step 1: Consigner** : Falco actif (modern_ebpf, noyau 6.17/BTF), 3 règles chargées ; alerte CRITICAL « shell » déclenchée et observée ; règle sortante silencieuse (cohérent isolation) ; note d'affinage sur la règle « processus inattendu » ; exception assumée (Falco privilégié = moniteur).
+- [ ] **Step 2: Commit** — `git commit -m "docs(eval): phase 6 results (Falco runtime monitoring, shell alert fired)"` ; push.
+
+## Critères de fin de phase 6
+
+- [ ] `falco/falco_rules.local.yaml` versionné (3 règles Annexe E).
+- [ ] Falco actif sur l'hôte (modern_ebpf), règles locales chargées sans erreur.
+- [ ] Un shell ouvert dans le conteneur Ollama déclenche l'alerte **CRITICAL** attendue.
+- [ ] La règle « connexion sortante » reste silencieuse en fonctionnement normal (isolation OK).
+
+## Notes / reporté
+- Persistance/agrégation des alertes dans un service de journalisation dédié + politique de rétention (loi 2024/017) : industrialisation, perspectives.
+- Affinage complet des règles par exceptions (allowlist de processus selon la version d'Ollama) : mise en production.
+- Campagne d'évaluation 3 axes complète = Phase 7.

--- a/eval/RESULTS-phase6.md
+++ b/eval/RESULTS-phase6.md
@@ -22,9 +22,12 @@ Ouverture d'un shell dans le conteneur Ollama (`docker exec … sh -c …`) :
 | **Shell ouvert dans le conteneur Ollama** | **CRITICAL** | ✅ (`shell=sh`) |
 | **Processus inattendu dans le conteneur Ollama** | WARNING | ✅ (`proc=sh`, `proc=whoami`) |
 
-> Point de configuration hôte : `rule_matching: all` dans `/etc/falco/falco.yaml` (le défaut récent
-> `first` ne déclenche que la première règle correspondante par événement, masquant la règle
-> CRITICAL au profit de la WARNING listée avant). Les règles de l'Annexe E restent **inchangées**.
+> **Robustesse (correctif de revue P6)** : les deux règles sont rendues **mutuellement exclusives**
+> — la règle « processus inattendu » exclut désormais les shells (traités par la règle CRITICAL).
+> Chaque processus déclenche donc exactement une règle, et la CRITICAL se déclenche **avec la
+> config Falco par défaut** (`rule_matching: first`) — plus aucune dépendance à un réglage hôte non
+> versionné (l'artefact `falco_rules.local.yaml` est autosuffisant). Vérifié : `sh` → CRITICAL,
+> sa commande enfant (`id`) → WARNING.
 
 ## Calibration empirique (affinage obligatoire, Annexe E)
 
@@ -45,6 +48,18 @@ n'initie aucune connexion Internet ; seule sa résolution DNS locale, désormais
 ## Non-régression
 - Le tuteur reste fonctionnel (Falco observe sans interférer) ; durcissement, WAF, isolation et
   confidentialité des phases précédentes préservés.
+
+## Correctifs / notes de revue (Opus) — aucun Critical
+- **I1** (le CRITICAL ne survivait que via `rule_matching: all`, réglage hôte non versionné) →
+  **fermé** : règles rendues mutuellement exclusives, autosuffisantes avec la config par défaut.
+- **I2** (allowlist par `proc.name` = surface d'évasion) → **atténué** : `runner` retiré (non observé,
+  nom d'usurpation gratuit) ; allowlist réduite au strict observé. **Limite connue documentée** :
+  un attaquant capable d'exécuter dans le conteneur pourrait renommer son binaire en `ollama` /
+  `ollama_llama_se` pour s'y soustraire — limite intrinsèque des règles `proc.name` (Annexe E) ; un
+  durcissement par `proc.exepath`/hash relève de la mise en production (le chemin est déjà journalisé
+  dans la sortie via `%proc.exepath`).
+- Liste de shells élargie (`busybox`, `ksh`, `csh`, `tcsh`, `fish`). Exception réseau : `::1` ne
+  quitte pas le namespace conteneur → n'atténue aucune exfiltration réelle.
 
 ## Notes / reporté
 - Persistance/agrégation des alertes dans un service de journalisation dédié + rétention conforme à

--- a/eval/RESULTS-phase6.md
+++ b/eval/RESULTS-phase6.md
@@ -1,0 +1,56 @@
+# Résultats d'évaluation — Phase 6 (supervision Falco)
+
+Évaluation de fin de Phase 6 : supervision en exécution par **Falco** sur l'hôte, ciblant le
+conteneur d'inférence Ollama. EC2 Ubuntu (noyau 6.17 + BTF), 2 vCPU / 8 Go.
+
+## Déploiement
+
+- **Falco 0.44.1** installé sur l'**hôte** EC2, pilote **modern eBPF** (CO-RE — noyau 6.17 avec
+  `/sys/kernel/btf/vmlinux` présent, aucun module à compiler). Service `falco-modern-bpf` actif.
+- Règles versionnées `falco/falco_rules.local.yaml` (Annexe E) déployées dans `/etc/falco/` et
+  chargées ; enrichissement conteneur opérationnel (`container.image.repository=ollama/ollama`,
+  `container_name=aimoodle-ollama-1`).
+- **Falco est le moniteur de sécurité** : il a légitimement des privilèges noyau (eBPF) — exception
+  assumée au principe de moindre privilège (c'est précisément son rôle).
+
+## Détection — une intrusion déclenche l'alerte
+
+Ouverture d'un shell dans le conteneur Ollama (`docker exec … sh -c …`) :
+
+| Alerte | Priorité | Observé |
+|---|---|---|
+| **Shell ouvert dans le conteneur Ollama** | **CRITICAL** | ✅ (`shell=sh`) |
+| **Processus inattendu dans le conteneur Ollama** | WARNING | ✅ (`proc=sh`, `proc=whoami`) |
+
+> Point de configuration hôte : `rule_matching: all` dans `/etc/falco/falco.yaml` (le défaut récent
+> `first` ne déclenche que la première règle correspondante par événement, masquant la règle
+> CRITICAL au profit de la WARNING listée avant). Les règles de l'Annexe E restent **inchangées**.
+
+## Calibration empirique (affinage obligatoire, Annexe E)
+
+L'Annexe E prévient que l'affinage des règles « n'est pas optionnel mais une étape obligatoire de
+mise en production ». Deux **faux positifs** ont été observés en fonctionnement normal, puis
+corrigés :
+
+| Faux positif observé | Cause | Correction |
+|---|---|---|
+| « Connexion sortante » `destination=::1:53 cmd=ollama serve` | résolution **DNS d'Ollama sur le loopback IPv6 `::1`** ; la règle n'excluait que `127.0.0.1` (IPv4) | ajout de `::1` à l'exception |
+| « Processus inattendu » `proc=ollama_llama_se parent=ollama` | le **sous-processus d'inférence** (comm tronqué à 15 car.) absent de l'allowlist `(ollama, runner)` | ajout de `ollama_llama_se` à l'allowlist |
+
+Après calibration : **0 faux positif** sur une inférence normale (mesuré), tandis qu'un shell
+déclenche toujours l'alerte CRITICAL. La règle « connexion sortante » reste par ailleurs
+**silencieuse** en fonctionnement normal — cohérent avec l'isolation réseau de la Phase 3 (Ollama
+n'initie aucune connexion Internet ; seule sa résolution DNS locale, désormais exclue, apparaissait).
+
+## Non-régression
+- Le tuteur reste fonctionnel (Falco observe sans interférer) ; durcissement, WAF, isolation et
+  confidentialité des phases précédentes préservés.
+
+## Notes / reporté
+- Persistance/agrégation des alertes dans un service de journalisation dédié + rétention conforme à
+  la loi 2024/017 : industrialisation, perspectives.
+- L'allowlist de processus dépend de la version d'Ollama (`ollama_llama_se` ici) ; à réajuster à
+  chaque montée de version (comme le note l'Annexe E).
+- `rule_matching: all` et l'installation de Falco relèvent du provisionnement de l'hôte (documentés
+  dans le plan `docs/superpowers/plans/2026-07-02-phase6-falco.md`).
+- Campagne d'évaluation 3 axes complète = Phase 7.

--- a/falco/falco_rules.local.yaml
+++ b/falco/falco_rules.local.yaml
@@ -9,19 +9,17 @@
 - macro: ollama_container
   condition: container.image.repository contains "ollama"
 
-# Interpreteurs de commandes (liste elargie) : partagee par les deux regles pour
-# les rendre MUTUELLEMENT EXCLUSIVES (un shell -> CRITICAL uniquement ; un autre
-# processus inattendu -> WARNING uniquement). Ainsi la CRITICAL se declenche meme
-# avec la config Falco par defaut (rule_matching: first), sans reglage hote.
-- macro: shell_binaries
-  condition: proc.name in (sh, bash, dash, ash, zsh, ksh, csh, tcsh, fish, busybox)
+# Les deux regles sont MUTUELLEMENT EXCLUSIVES (un shell -> CRITICAL uniquement ; un
+# autre processus inattendu -> WARNING uniquement) : la CRITICAL se declenche donc meme
+# avec la config Falco par defaut (rule_matching: first), sans reglage hote. Les listes
+# sont inlinees (l'expansion d'une macro 'not' casse la precedence de 'in (...)').
 
 - rule: Ollama - processus inattendu
   desc: Tout processus non attendu (hors shell) dans le conteneur Ollama
-  # Allowlist calibree a la version deployee : 'ollama_llama_se' = sous-processus
-  # d'inference (comm tronque a 15 car.). 'runner' retire (non observe = nom
-  # d'usurpation gratuit). Les shells sont exclus ici (traites en CRITICAL ci-dessous).
-  condition: spawned_process and ollama_container and not proc.name in (ollama, ollama_llama_se) and not shell_binaries
+  # Exclusion = allowlist legitime + les shells (traites en CRITICAL ci-dessous).
+  # 'ollama_llama_se' = sous-processus d'inference (comm tronque a 15 car.).
+  # 'runner' retire (non observe = nom d'usurpation gratuit).
+  condition: spawned_process and ollama_container and not proc.name in (ollama, ollama_llama_se, sh, bash, dash, ash, zsh, ksh, csh, tcsh, fish, busybox)
   output: >
     Processus inattendu dans le conteneur Ollama
     (proc=%proc.name exe=%proc.exepath parent=%proc.pname cmd=%proc.cmdline
@@ -31,7 +29,7 @@
 
 - rule: Ollama - interpreteur de commandes
   desc: Un shell est lance dans le conteneur Ollama (exploitation probable)
-  condition: spawned_process and ollama_container and shell_binaries
+  condition: spawned_process and ollama_container and proc.name in (sh, bash, dash, ash, zsh, ksh, csh, tcsh, fish, busybox)
   output: >
     Shell ouvert dans le conteneur Ollama
     (shell=%proc.name exe=%proc.exepath parent=%proc.pname cmd=%proc.cmdline)

--- a/falco/falco_rules.local.yaml
+++ b/falco/falco_rules.local.yaml
@@ -1,32 +1,47 @@
 # falco_rules.local.yaml -- supervision du conteneur d'inference Ollama (Annexe E).
+#
+# Note de robustesse : les regles reposent sur proc.name (comme l'Annexe E). C'est une
+# heuristique : un attaquant capable d'executer dans le conteneur pourrait renommer son
+# binaire pour usurper l'allowlist (limite connue, cf. RESULTS-phase6). Un durcissement
+# par proc.exepath/hash releve de la mise en production. L'allowlist est reduite au strict
+# necessaire observe (binaire ollama + sous-processus d'inference) pour limiter cette surface.
+
 - macro: ollama_container
   condition: container.image.repository contains "ollama"
 
+# Interpreteurs de commandes (liste elargie) : partagee par les deux regles pour
+# les rendre MUTUELLEMENT EXCLUSIVES (un shell -> CRITICAL uniquement ; un autre
+# processus inattendu -> WARNING uniquement). Ainsi la CRITICAL se declenche meme
+# avec la config Falco par defaut (rule_matching: first), sans reglage hote.
+- macro: shell_binaries
+  condition: proc.name in (sh, bash, dash, ash, zsh, ksh, csh, tcsh, fish, busybox)
+
 - rule: Ollama - processus inattendu
-  desc: Tout processus autre que le binaire ollama dans le conteneur
-  # Allowlist calibree a la version deployee (Annexe E : affinage obligatoire) :
-  # 'ollama_llama_se' est le sous-processus d'inference (comm tronque a 15 car.).
-  condition: spawned_process and ollama_container and not proc.name in (ollama, runner, ollama_llama_se)
+  desc: Tout processus non attendu (hors shell) dans le conteneur Ollama
+  # Allowlist calibree a la version deployee : 'ollama_llama_se' = sous-processus
+  # d'inference (comm tronque a 15 car.). 'runner' retire (non observe = nom
+  # d'usurpation gratuit). Les shells sont exclus ici (traites en CRITICAL ci-dessous).
+  condition: spawned_process and ollama_container and not proc.name in (ollama, ollama_llama_se) and not shell_binaries
   output: >
     Processus inattendu dans le conteneur Ollama
-    (proc=%proc.name parent=%proc.pname cmd=%proc.cmdline
+    (proc=%proc.name exe=%proc.exepath parent=%proc.pname cmd=%proc.cmdline
      image=%container.image.repository)
   priority: WARNING
   tags: [container, llm, mitre_execution]
 
 - rule: Ollama - interpreteur de commandes
   desc: Un shell est lance dans le conteneur Ollama (exploitation probable)
-  condition: spawned_process and ollama_container and proc.name in (sh, bash, dash, ash, zsh)
+  condition: spawned_process and ollama_container and shell_binaries
   output: >
     Shell ouvert dans le conteneur Ollama
-    (shell=%proc.name parent=%proc.pname cmd=%proc.cmdline)
+    (shell=%proc.name exe=%proc.exepath parent=%proc.pname cmd=%proc.cmdline)
   priority: CRITICAL
   tags: [container, llm, shell]
 
 - rule: Ollama - connexion sortante interdite
   desc: Ollama est isole ; toute sortie reseau signale une exfiltration
-  # Exception loopback IPv4 ET IPv6 (Annexe E : la resolution DNS locale d'Ollama
-  # cible ::1:53 ; sans ::1 la regle produit un faux positif a chaque requete).
+  # Exception loopback IPv4 et IPv6 (la resolution DNS locale d'Ollama cible ::1:53 ;
+  # ::1 ne quitte pas le namespace reseau, donc n'est pas une exfiltration).
   condition: outbound and ollama_container and not fd.sip in ("127.0.0.1", "::1")
   output: >
     Connexion sortante depuis le conteneur Ollama

--- a/falco/falco_rules.local.yaml
+++ b/falco/falco_rules.local.yaml
@@ -1,0 +1,31 @@
+# falco_rules.local.yaml -- supervision du conteneur d'inference Ollama (Annexe E).
+- macro: ollama_container
+  condition: container.image.repository contains "ollama"
+
+- rule: Ollama - processus inattendu
+  desc: Tout processus autre que le binaire ollama dans le conteneur
+  condition: spawned_process and ollama_container and not proc.name in (ollama, runner)
+  output: >
+    Processus inattendu dans le conteneur Ollama
+    (proc=%proc.name parent=%proc.pname cmd=%proc.cmdline
+     image=%container.image.repository)
+  priority: WARNING
+  tags: [container, llm, mitre_execution]
+
+- rule: Ollama - interpreteur de commandes
+  desc: Un shell est lance dans le conteneur Ollama (exploitation probable)
+  condition: spawned_process and ollama_container and proc.name in (sh, bash, dash, ash, zsh)
+  output: >
+    Shell ouvert dans le conteneur Ollama
+    (shell=%proc.name parent=%proc.pname cmd=%proc.cmdline)
+  priority: CRITICAL
+  tags: [container, llm, shell]
+
+- rule: Ollama - connexion sortante interdite
+  desc: Ollama est isole ; toute sortie reseau signale une exfiltration
+  condition: outbound and ollama_container and not fd.sip in ("127.0.0.1")
+  output: >
+    Connexion sortante depuis le conteneur Ollama
+    (destination=%fd.sip:%fd.sport cmd=%proc.cmdline)
+  priority: CRITICAL
+  tags: [network, llm, exfiltration]

--- a/falco/falco_rules.local.yaml
+++ b/falco/falco_rules.local.yaml
@@ -4,7 +4,9 @@
 
 - rule: Ollama - processus inattendu
   desc: Tout processus autre que le binaire ollama dans le conteneur
-  condition: spawned_process and ollama_container and not proc.name in (ollama, runner)
+  # Allowlist calibree a la version deployee (Annexe E : affinage obligatoire) :
+  # 'ollama_llama_se' est le sous-processus d'inference (comm tronque a 15 car.).
+  condition: spawned_process and ollama_container and not proc.name in (ollama, runner, ollama_llama_se)
   output: >
     Processus inattendu dans le conteneur Ollama
     (proc=%proc.name parent=%proc.pname cmd=%proc.cmdline
@@ -23,7 +25,9 @@
 
 - rule: Ollama - connexion sortante interdite
   desc: Ollama est isole ; toute sortie reseau signale une exfiltration
-  condition: outbound and ollama_container and not fd.sip in ("127.0.0.1")
+  # Exception loopback IPv4 ET IPv6 (Annexe E : la resolution DNS locale d'Ollama
+  # cible ::1:53 ; sans ::1 la regle produit un faux positif a chaque requete).
+  condition: outbound and ollama_container and not fd.sip in ("127.0.0.1", "::1")
   output: >
     Connexion sortante depuis le conteneur Ollama
     (destination=%fd.sip:%fd.sport cmd=%proc.cmdline)


### PR DESCRIPTION
Objectif

Concrétiser la supervision runtime : Falco (eBPF) sur l'hôte observant le conteneur d'inférence Ollama, avec les 3 règles  de l'Annexe E, et démonstration qu'une intrusion déclenche l'alerte.

Contenu

- falco/falco_rules.local.yaml : macro ollama_container + 3 règles (processus inattendu = WARNING ; shell = CRITICAL ; connexion sortante = CRITICAL).
- Provisionnement hôte (documenté dans le plan) : Falco 0.44.1, pilote modern_ebpf (noyau 6.17 + BTF), rule_matching: all.

Vérifications (EC2)

- Shell dans le conteneur Ollama → CRITICAL « Shell ouvert » + WARNING (enrichi : image=ollama/ollama, container=aimoodle-ollama-1).
- Calibration (Annexe E) après faux positifs runtime : exception sortante ::1 (DNS loopback IPv6 d'Ollama) ; allowlist processus +ollama_llama_se (sous-processus d'inférence). → 0 faux positif en inférence normale ; règle sortante silencieuse (cohérent avec l'isolation).
- Non-régression : tuteur fonctionnel, pile inchangée.

Notes

- Falco = moniteur privilégié (exception assumée). Règles mutuellement exclusives → la CRITICAL se déclenche
  avec la config Falco par défaut, sans réglage hôte.

Reporté

Agrégation des alertes dans un service de journalisation dédié (loi 2024/017) = perspective. Phase 7 : campagne d'évaluation complète 3 axes.